### PR TITLE
Change the openjdk to adoptjdk

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/Migrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/Migrations.scala
@@ -41,7 +41,6 @@ class Migrations {
     updateCandidateDefault("maven", "3.5.3")
   }
 
-
   @ChangeSet(order = "008", id = "008-change_openjdk_to_adoptopenjdk", author = "MaSven")
   def migrate008(implicit db: MongoDatabase) = {
     updateVersion("9u181-openjdk", "9u181-adoptopenjdk")
@@ -53,6 +52,15 @@ class Migrations {
   def migrate007(implicit db: MongoDatabase) = {
     insertVersions(CandidateVersion("scala", "2.12.5", Some("UNIVERSAL"), "https://downloads.lightbend.com/scala/2.12.5/scala-2.12.5.zip"))
     updateCandidateDefault("scala", "2.12.5")
+
+  }
+
+  @ChangeSet(order = "009", id = "009-add_java_10_openjdk", author = "MaSven")
+  def migrate009(implicit db: MongoDatabase) = {
+    insertVersions(
+      CandidateVersion("java", "10-openjdk", Some("WINDOWS_64"), "https://download.java.net/java/GA/jdk10/10/binaries/openjdk-10_windows-x64_bin.tar.gz"),
+      CandidateVersion("java", "10-openjdk", Some("MAC_OSX"), "https://download.java.net/java/GA/jdk10/10/binaries/openjdk-10_osx-x64_bin.tar.gz"),
+      CandidateVersion("java", "10-openjdk", Some("LINUX_64"), "https://download.java.net/java/GA/jdk10/10/binaries/openjdk-10_linux-x64_bin.tar.gz"))
 
   }
 }

--- a/src/main/scala/io/sdkman/changelogs/Migrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/Migrations.scala
@@ -1,10 +1,11 @@
 package io.sdkman.changelogs
 
-import com.github.mongobee.changeset.{ChangeLog, ChangeSet}
+import com.github.mongobee.changeset.{ ChangeLog, ChangeSet }
 import com.mongodb.client.MongoDatabase
 import org.bson.Document
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
 
 @ChangeLog(order = "001")
 class VersionsMigration {
@@ -35,10 +36,16 @@ class VersionsMigration {
   @ChangeSet(order = "005", id = "005-change_java_default_8u152_zulu", author = "MaSven")
   def migrate005(implicit db: MongoDatabase) = updateCandidateDefault("java", "8u152-zulu")
 
-
   @ChangeSet(order = "006", id = "003-add_maven_353", author = "hho")
   def migrate006(implicit db: MongoDatabase) = {
     insertVersions(CandidateVersion("maven", "3.5.3", Some("UNIVERSAL"), "https://archive.apache.org/dist/maven/maven-3/3.5.3/binaries/apache-maven-3.5.3-bin.zip"))
     updateCandidateDefault("maven", "3.5.3")
+  }
+
+  @ChangeSet(order = "007", id = "007-change_openjdk_to_adoptopnjdk", author = "MaSven")
+  def migrate007(implicit db: MongoDatabase) = {
+    updateVersion("9u181-openjdk", "9u181-adoptopenjdk")
+    updateVersion("8u144-openjdk", "8u144-adoptopenjdk")
+    updateVersion("10u23-openjdk", "10u23-adoptopenjdk")
   }
 }

--- a/src/main/scala/io/sdkman/changelogs/Migrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/Migrations.scala
@@ -42,7 +42,7 @@ class VersionsMigration {
     updateCandidateDefault("maven", "3.5.3")
   }
 
-  @ChangeSet(order = "007", id = "007-change_openjdk_to_adoptopnjdk", author = "MaSven")
+  @ChangeSet(order = "007", id = "007-change_openjdk_to_adoptopenjdk", author = "MaSven")
   def migrate007(implicit db: MongoDatabase) = {
     updateVersion("9u181-openjdk", "9u181-adoptopenjdk")
     updateVersion("8u144-openjdk", "8u144-adoptopenjdk")

--- a/src/main/scala/io/sdkman/changelogs/Migrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/Migrations.scala
@@ -5,7 +5,6 @@ import com.mongodb.client.MongoDatabase
 import org.bson.Document
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable.ListBuffer
 
 @ChangeLog(order = "001")
 class VersionsMigration {

--- a/src/main/scala/io/sdkman/changelogs/package.scala
+++ b/src/main/scala/io/sdkman/changelogs/package.scala
@@ -1,26 +1,29 @@
 package io.sdkman
 
 import com.mongodb.client.MongoDatabase
-import com.mongodb.client.model.{Filters, Updates}
+import com.mongodb.client.model.{ Filters, Updates }
 import org.bson.Document
 
 import scala.language.implicitConversions
 
 import scala.collection.JavaConverters._
+import scala.collection.immutable.List
 
 package object changelogs {
 
-  case class Candidate(candidate: String,
-                       name: String,
-                       description: String,
-                       default: String,
-                       websiteUrl: String,
-                       distribution: String)
+  case class Candidate(
+    candidate:    String,
+    name:         String,
+    description:  String,
+    default:      String,
+    websiteUrl:   String,
+    distribution: String)
 
-  case class CandidateVersion(candidate: String,
-                              version: String,
-                              platform: Option[String],
-                              url: String)
+  case class CandidateVersion(
+    candidate: String,
+    version:   String,
+    platform:  Option[String],
+    url:       String)
 
   implicit def candidateToDocument(c: Candidate): Document =
     new Document("candidate", c.candidate)
@@ -44,4 +47,9 @@ package object changelogs {
 
   def updateCandidateDefault(candidate: String, version: String)(implicit db: MongoDatabase): Document =
     db.getCollection("candidates").findOneAndUpdate(Filters.eq("candidate", candidate), Updates.set("default", version))
+
+  def updateVersion(version: String, newVersion: String)(implicit db: MongoDatabase): Unit = {
+    db.getCollection("versions").updateMany(Filters.eq("version", version), Updates.set("version", newVersion))
+  }
+
 }


### PR DESCRIPTION
I think people will get confused with the openjdk suffic since openjdk releases it's own builds. So i changed the suffix for the adoptopenjdk to -adoptopenjdk. Also to make clear that this are not the openjdk builds.