### PR TITLE
Adds graalvm 1.0.0-rc4

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -279,4 +279,16 @@ class JavaMigrations {
       .validate()
       .insert()
   }
+
+  @ChangeSet(order = "031", id = "031-add_graalvm_1_0_0_rc_4", author = "wololock")
+  def migrate031(implicit db: MongoDatabase) = {
+    removeVersion("java", "1.0.0-rc3-graal", Linux64)
+    Version(
+      candidate = "java",
+      version = "1.0.0-rc4-graal",
+      url = "https://github.com/oracle/graal/releases/download/vm-1.0.0-rc4/graalvm-ce-1.0.0-rc4-linux-amd64.tar.gz",
+      platform = Linux64)
+      .validate()
+      .insert()
+  }
 }


### PR DESCRIPTION
This pull requests upgrades GraalVM to latest 1.0.0-RC4 version released 2 days ago (https://medium.com/graalvm/graalvm-1-0-rc4-release-notes-ba52bec3b4d7)

