### PR TITLE
Add CUBA CLI migrations

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/CubaCliMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/CubaCliMigrations.scala
@@ -1,0 +1,40 @@
+package io.sdkman.changelogs
+
+import com.github.mongobee.changeset.{ChangeLog, ChangeSet}
+import com.mongodb.client.MongoDatabase
+
+@ChangeLog(order = "014")
+class CubaCliMigrations {
+
+  @ChangeSet(order = "001", id = "001_add_cubacli_candidate", author = "jreznot")
+  def migration001(implicit db: MongoDatabase) = {
+    Candidate(
+      candidate = "cubacli",
+      name = "CUBA CLI",
+      description = "CUBA CLI is an open source command line utility that enables you to easily create projects based on CUBA Platform",
+      websiteUrl = "https://cuba-platform.com",
+      distribution = "PLATFORM_SPECIFIC"
+    ).insert()
+
+    Version(
+      candidate = "cubacli",
+      version = "1.0.1",
+      url = "https://bintray.com/cuba-platform/tools/download_file?file_path=cuba-cli%2F1.0.1%2Fcuba-cli-1.0.1-linux.zip",
+      platform = Linux64
+    ).insert()
+
+    Version(
+      candidate = "cubacli",
+      version = "1.0.1",
+      url = "https://bintray.com/cuba-platform/tools/download_file?file_path=cuba-cli%2F1.0.1%2Fcuba-cli-1.0.1-macos.zip",
+      platform = MacOSX
+    ).insert()
+
+    Version(
+      candidate = "cubacli",
+      version = "1.0.1",
+      url = "https://bintray.com/cuba-platform/tools/download_file?file_path=cuba-cli%2F1.0.1%2Fcuba-cli-1.0.1-windows.zip",
+      platform = Windows
+    ).insert()
+  }
+}

--- a/src/main/scala/io/sdkman/changelogs/CubaCliMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/CubaCliMigrations.scala
@@ -9,7 +9,7 @@ class CubaCliMigrations {
   @ChangeSet(order = "001", id = "001_add_cubacli_candidate", author = "jreznot")
   def migration001(implicit db: MongoDatabase) = {
     Candidate(
-      candidate = "cubacli",
+      candidate = "cuba-cli",
       name = "CUBA CLI",
       description = "CUBA CLI is an open source command line utility that enables you to easily create projects based on CUBA Platform",
       websiteUrl = "https://cuba-platform.com",
@@ -18,19 +18,19 @@ class CubaCliMigrations {
 
     List(
       Version(
-        candidate = "cubacli",
+        candidate = "cuba-cli",
         version = "1.0.1",
         url = "https://bintray.com/cuba-platform/tools/download_file?file_path=cuba-cli%2F1.0.1%2Fcuba-cli-1.0.1-linux.zip",
         platform = Linux64
       ),
       Version(
-        candidate = "cubacli",
+        candidate = "cuba-cli",
         version = "1.0.1",
         url = "https://bintray.com/cuba-platform/tools/download_file?file_path=cuba-cli%2F1.0.1%2Fcuba-cli-1.0.1-macos.zip",
         platform = MacOSX
       ),
       Version(
-        candidate = "cubacli",
+        candidate = "cuba-cli",
         version = "1.0.1",
         url = "https://bintray.com/cuba-platform/tools/download_file?file_path=cuba-cli%2F1.0.1%2Fcuba-cli-1.0.1-windows.zip",
         platform = Windows

--- a/src/main/scala/io/sdkman/changelogs/CubaCliMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/CubaCliMigrations.scala
@@ -16,25 +16,26 @@ class CubaCliMigrations {
       distribution = "PLATFORM_SPECIFIC"
     ).insert()
 
-    Version(
-      candidate = "cubacli",
-      version = "1.0.1",
-      url = "https://bintray.com/cuba-platform/tools/download_file?file_path=cuba-cli%2F1.0.1%2Fcuba-cli-1.0.1-linux.zip",
-      platform = Linux64
-    ).insert()
-
-    Version(
-      candidate = "cubacli",
-      version = "1.0.1",
-      url = "https://bintray.com/cuba-platform/tools/download_file?file_path=cuba-cli%2F1.0.1%2Fcuba-cli-1.0.1-macos.zip",
-      platform = MacOSX
-    ).insert()
-
-    Version(
-      candidate = "cubacli",
-      version = "1.0.1",
-      url = "https://bintray.com/cuba-platform/tools/download_file?file_path=cuba-cli%2F1.0.1%2Fcuba-cli-1.0.1-windows.zip",
-      platform = Windows
-    ).insert()
+    List(
+      Version(
+        candidate = "cubacli",
+        version = "1.0.1",
+        url = "https://bintray.com/cuba-platform/tools/download_file?file_path=cuba-cli%2F1.0.1%2Fcuba-cli-1.0.1-linux.zip",
+        platform = Linux64
+      ),
+      Version(
+        candidate = "cubacli",
+        version = "1.0.1",
+        url = "https://bintray.com/cuba-platform/tools/download_file?file_path=cuba-cli%2F1.0.1%2Fcuba-cli-1.0.1-macos.zip",
+        platform = MacOSX
+      ),
+      Version(
+        candidate = "cubacli",
+        version = "1.0.1",
+        url = "https://bintray.com/cuba-platform/tools/download_file?file_path=cuba-cli%2F1.0.1%2Fcuba-cli-1.0.1-windows.zip",
+        platform = Windows
+      ))
+      .validate()
+      .insert()
   }
 }

--- a/src/main/scala/io/sdkman/changelogs/CubaCliMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/CubaCliMigrations.scala
@@ -20,19 +20,19 @@ class CubaCliMigrations {
       Version(
         candidate = "cuba-cli",
         version = "1.0.1",
-        url = "https://bintray.com/cuba-platform/tools/download_file?file_path=cuba-cli%2F1.0.1%2Fcuba-cli-1.0.1-linux.zip",
+        url = "https://cuba-platform.bintray.com/tools/cuba-cli/1.0.1/cuba-cli-1.0.1-linux.zip",
         platform = Linux64
       ),
       Version(
         candidate = "cuba-cli",
         version = "1.0.1",
-        url = "https://bintray.com/cuba-platform/tools/download_file?file_path=cuba-cli%2F1.0.1%2Fcuba-cli-1.0.1-macos.zip",
+        url = "https://cuba-platform.bintray.com/tools/cuba-cli/1.0.1/cuba-cli-1.0.1-macos.zip",
         platform = MacOSX
       ),
       Version(
         candidate = "cuba-cli",
         version = "1.0.1",
-        url = "https://bintray.com/cuba-platform/tools/download_file?file_path=cuba-cli%2F1.0.1%2Fcuba-cli-1.0.1-windows.zip",
+        url = "https://cuba-platform.bintray.com/tools/cuba-cli/1.0.1/cuba-cli-1.0.1-windows.zip",
         platform = Windows
       ))
       .validate()


### PR DESCRIPTION
I've added the CUBA CLI migrations to make `cuba-cli` util available on the sdkman. For now, we distribute ZIP archive for Linux / Windows / Mac OS and its is platform specific archive.