### PR TITLE
Update Zulu JDKs

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -329,4 +329,43 @@ class JavaMigrations {
       .validate()
       .insert()
   }
+
+  @ChangeSet(order = "035", id = "035-add_zulu_6_0_113", author = "vpavic")
+  def migrate035(implicit db: MongoDatabase) = {
+    Seq(Linux64, Windows).foreach(platform => removeVersion(candidate = "java", version = "6.0.107-zulu", platform))
+    List(
+      Version("java", "6.0.113-zulu", "https://cdn.azul.com/zulu/bin/zulu6.21.0.3-jdk6.0.113-linux_x64.tar.gz", Linux64),
+      Version("java", "6.0.113-zulu", "https://cdn.azul.com/zulu/bin/zulu6.21.0.3-jdk6.0.113-win_x64.zip", Windows)
+    ).validate().insert()
+  }
+
+  @ChangeSet(order = "036", id = "036-add_zulu_7_0_191", author = "vpavic")
+  def migrate036(implicit db: MongoDatabase) = {
+    Seq(Linux64, Windows).foreach(platform => removeVersion(candidate = "java", version = "7.0.181-zulu", platform))
+    List(
+      Version("java", "7.0.191-zulu", "https://cdn.azul.com/zulu/bin/zulu7.24.0.1-jdk7.0.191-linux_x64.tar.gz", Linux64),
+      Version("java", "7.0.191-zulu", "https://cdn.azul.com/zulu/bin/zulu7.24.0.1-jdk7.0.191-win_x64.zip", Windows)
+    ).validate().insert()
+  }
+
+  @ChangeSet(order = "037", id = "037-add_zulu_8_0_181", author = "vpavic")
+  def migrate037(implicit db: MongoDatabase) = {
+    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "8.0.172-zulu", platform))
+    List(
+      Version("java", "8.0.181-zulu", "https://cdn.azul.com/zulu/bin/zulu8.31.0.1-jdk8.0.181-linux_x64.tar.gz", Linux64),
+      Version("java", "8.0.181-zulu", "https://cdn.azul.com/zulu/bin/zulu8.31.0.1-jdk8.0.181-win_x64.zip", Windows),
+      Version("java", "8.0.181-zulu", "https://cdn.azul.com/zulu/bin/zulu8.31.0.1-jdk8.0.181-macosx_x64.tar.gz", MacOSX)
+    ).validate().insert()
+  }
+
+  @ChangeSet(order = "038", id = "038-add_zulu_10_0_2", author = "vpavic")
+  def migrate038(implicit db: MongoDatabase) = {
+    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "10.0.1-zulu", platform))
+    List(
+      Version("java", "10.0.2-zulu", "https://cdn.azul.com/zulu/bin/zulu10.3+5-jdk10.0.2-linux_x64.tar.gz", Linux64),
+      Version("java", "10.0.2-zulu", "https://cdn.azul.com/zulu/bin/zulu10.3+5-jdk10.0.2-win_x64.zip", Windows),
+      Version("java", "10.0.2-zulu", "https://cdn.azul.com/zulu/bin/zulu10.3+5-jdk10.0.2-macosx_x64.tar.gz", MacOSX)
+    ).validate().insert()
+  }
+
 }


### PR DESCRIPTION
This PR updates Zulu JDKs to current versions. There's also an additional commit that adds Zulu `11-ea`, if that's acceptable addition.