### PR TITLE
Add OpenJDK versions [8, 10, 11] with OpenJ9

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -322,4 +322,31 @@ class JavaMigrations {
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "12.ea.17-open", _))
   }
 
+  @ChangeSet(order = "065", id = "065-add_eclipsej9_openjdk_8", author = "munukutla")
+  def migrate065(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "8-j9", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u192-b12_openj9-0.11.0/OpenJDK8U-jdk_x64_linux_openj9_8u192b12_openj9-0.11.0.tar.gz", Linux64),
+      Version("java", "8-j9", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u192-b12_openj9-0.11.0/OpenJDK8U-jdk_x64_windows_openj9_8u192b12_openj9-0.11.0.zip", Windows))
+      .validate()
+      .insert()
+  }
+
+  @ChangeSet(order = "066", id = "066-add_eclipsej9_openjdk_10", author = "munukutla")
+  def migrate065(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "10-j9", "https://github.com/AdoptOpenJDK/openjdk10-openj9-releases/releases/download/jdk-10.0.2%2B13_openj9-0.9.0/OpenJDK10-OPENJ9_x64_Linux_jdk-10.0.2.13_openj9-0.9.0.tar.gz", Linux64),
+      Version("java", "10-j9", "https://github.com/AdoptOpenJDK/openjdk10-openj9-releases/releases/download/jdk-10.0.2%2B13_openj9-0.9.0/OpenJDK10-OPENJ9_x64_Windows_jdk-10.0.2.13_openj9-0.9.0.zip", Windows))
+      .validate()
+      .insert()
+  }
+
+  @ChangeSet(order = "067", id = "067-add_eclipsej9_openjdk_11", author = "munukutla")
+  def migrate065(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "11-j9", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_linux_openj9_jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.tar.gz", Linux64),
+      Version("java", "11-j9", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_mac_openj9_jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.tar.gz", MacOSX),
+      Version("java", "11-j9", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_windows_openj9_jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.zip", Windows))
+      .validate()
+      .insert()
+  }
 }

--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -325,8 +325,8 @@ class JavaMigrations {
   @ChangeSet(order = "065", id = "065-add_eclipsej9_openjdk_8", author = "munukutla")
   def migrate065(implicit db: MongoDatabase) = {
     List(
-      Version("java", "8-j9", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u192-b12_openj9-0.11.0/OpenJDK8U-jdk_x64_linux_openj9_8u192b12_openj9-0.11.0.tar.gz", Linux64),
-      Version("java", "8-j9", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u192-b12_openj9-0.11.0/OpenJDK8U-jdk_x64_windows_openj9_8u192b12_openj9-0.11.0.zip", Windows))
+      Version("java", "8-open-j9", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u192-b12_openj9-0.11.0/OpenJDK8U-jdk_x64_linux_openj9_8u192b12_openj9-0.11.0.tar.gz", Linux64),
+      Version("java", "8-open-j9", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u192-b12_openj9-0.11.0/OpenJDK8U-jdk_x64_windows_openj9_8u192b12_openj9-0.11.0.zip", Windows))
       .validate()
       .insert()
   }
@@ -334,8 +334,8 @@ class JavaMigrations {
   @ChangeSet(order = "066", id = "066-add_eclipsej9_openjdk_10", author = "munukutla")
   def migrate066(implicit db: MongoDatabase) = {
     List(
-      Version("java", "10-j9", "https://github.com/AdoptOpenJDK/openjdk10-openj9-releases/releases/download/jdk-10.0.2%2B13_openj9-0.9.0/OpenJDK10-OPENJ9_x64_Linux_jdk-10.0.2.13_openj9-0.9.0.tar.gz", Linux64),
-      Version("java", "10-j9", "https://github.com/AdoptOpenJDK/openjdk10-openj9-releases/releases/download/jdk-10.0.2%2B13_openj9-0.9.0/OpenJDK10-OPENJ9_x64_Windows_jdk-10.0.2.13_openj9-0.9.0.zip", Windows))
+      Version("java", "10-open-j9", "https://github.com/AdoptOpenJDK/openjdk10-openj9-releases/releases/download/jdk-10.0.2%2B13_openj9-0.9.0/OpenJDK10-OPENJ9_x64_Linux_jdk-10.0.2.13_openj9-0.9.0.tar.gz", Linux64),
+      Version("java", "10-open-j9", "https://github.com/AdoptOpenJDK/openjdk10-openj9-releases/releases/download/jdk-10.0.2%2B13_openj9-0.9.0/OpenJDK10-OPENJ9_x64_Windows_jdk-10.0.2.13_openj9-0.9.0.zip", Windows))
       .validate()
       .insert()
   }
@@ -343,9 +343,9 @@ class JavaMigrations {
   @ChangeSet(order = "067", id = "067-add_eclipsej9_openjdk_11", author = "munukutla")
   def migrate067(implicit db: MongoDatabase) = {
     List(
-      Version("java", "11-j9", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_linux_openj9_jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.tar.gz", Linux64),
-      Version("java", "11-j9", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_mac_openj9_jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.tar.gz", MacOSX),
-      Version("java", "11-j9", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_windows_openj9_jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.zip", Windows))
+      Version("java", "11-open-j9", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_linux_openj9_jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.tar.gz", Linux64),
+      Version("java", "11-open-j9", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_mac_openj9_jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.tar.gz", MacOSX),
+      Version("java", "11-open-j9", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_windows_openj9_jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.zip", Windows))
       .validate()
       .insert()
   }

--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -332,7 +332,7 @@ class JavaMigrations {
   }
 
   @ChangeSet(order = "066", id = "066-add_eclipsej9_openjdk_10", author = "munukutla")
-  def migrate065(implicit db: MongoDatabase) = {
+  def migrate066(implicit db: MongoDatabase) = {
     List(
       Version("java", "10-j9", "https://github.com/AdoptOpenJDK/openjdk10-openj9-releases/releases/download/jdk-10.0.2%2B13_openj9-0.9.0/OpenJDK10-OPENJ9_x64_Linux_jdk-10.0.2.13_openj9-0.9.0.tar.gz", Linux64),
       Version("java", "10-j9", "https://github.com/AdoptOpenJDK/openjdk10-openj9-releases/releases/download/jdk-10.0.2%2B13_openj9-0.9.0/OpenJDK10-OPENJ9_x64_Windows_jdk-10.0.2.13_openj9-0.9.0.zip", Windows))
@@ -341,7 +341,7 @@ class JavaMigrations {
   }
 
   @ChangeSet(order = "067", id = "067-add_eclipsej9_openjdk_11", author = "munukutla")
-  def migrate065(implicit db: MongoDatabase) = {
+  def migrate066(implicit db: MongoDatabase) = {
     List(
       Version("java", "11-j9", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_linux_openj9_jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.tar.gz", Linux64),
       Version("java", "11-j9", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_mac_openj9_jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.tar.gz", MacOSX),

--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -341,7 +341,7 @@ class JavaMigrations {
   }
 
   @ChangeSet(order = "067", id = "067-add_eclipsej9_openjdk_11", author = "munukutla")
-  def migrate066(implicit db: MongoDatabase) = {
+  def migrate067(implicit db: MongoDatabase) = {
     List(
       Version("java", "11-j9", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_linux_openj9_jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.tar.gz", Linux64),
       Version("java", "11-j9", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_mac_openj9_jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.tar.gz", MacOSX),


### PR DESCRIPTION
Added migrations to use OpenJDK with OpenJ9.

| Version          | Platforms      |
|------------------|----------------|
| OpenJDK 8 (LTS)  | Linux, Windows |
| OpenJDK 10       | Linux, Windows |
| OpenJDK 11 (LTS) | Linux, Mac, Windows |