### PR TITLE
Added GraalVM 1.0.0-RC11

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -343,5 +343,22 @@ class JavaMigrations {
       .insert()
   }
 
+  @ChangeSet(order = "069", id = "069-add_graalvm_1_0_0_rc_11", author = "wololock")
+  def migrate069(implicit db: MongoDatabase) = {
+    List(
+      Version(
+        candidate = "java",
+        version = "1.0.0-rc-11-grl",
+        url = "https://github.com/oracle/graal/releases/download/vm-1.0.0-rc11/graalvm-ce-1.0.0-rc11-linux-amd64.tar.gz",
+        platform = Linux64),
+      Version(
+        candidate = "java",
+        version = "1.0.0-rc-11-grl",
+        url = "https://github.com/oracle/graal/releases/download/vm-1.0.0-rc11/graalvm-ce-1.0.0-rc11-macos-amd64.tar.gz",
+        platform = MacOSX))
+      .validate()
+      .insert()
+  }
+
 
 }


### PR DESCRIPTION
Release notes: https://github.com/oracle/graal/releases/tag/vm-1.0.0-rc11

I used th same version pattern found for last 3 GraalVM versions available in SDKMAN:

```
1.0.0-rc-10-grl                                        
1.0.0-rc-9-grl                                         
1.0.0-rc-8-grl   
```