### PR TITLE
Add OpenJDK 8u202 and 11.0.2 with OpenJ9 0.12.0

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -390,4 +390,22 @@ class JavaMigrations {
       .validate()
       .insert()
   }
+
+  @ChangeSet(order = "081", id = "081-add_openj9_8_0_202", author = "joschi")
+  def migrate081(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "8.0.202-j9-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u202-b08/OpenJDK8U-jdk_x64_linux_openj9_8u202b08_openj9-0.12.0.tar.gz", Linux64),
+      Version("java", "8.0.202-j9-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u202-b08/OpenJDK8U-jdk_x64_windows_openj9_8u202b08_openj9-0.12.0.zip", Windows),
+      Version("java", "8.0.202-j9-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u202-b08/OpenJDK8U-jdk_x64_mac_openj9_8u202b08_openj9-0.12.0.tar.gz", MacOSX)
+    ).validate().insert()
+  }
+
+  @ChangeSet(order = "082", id = "082-add_openj9_11_0_2", author = "joschi")
+  def migrate082(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "11.0.2-j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_x64_linux_openj9_11.0.2_9_openj9-0.12.0.tar.gz", Linux64),
+      Version("java", "11.0.2-j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_x64_windows_openj9_11.0.2_9_openj9-0.12.0.zip", Windows),
+      Version("java", "11.0.2-j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_x64_mac_openj9_11.0.2_9_openj9-0.12.0.tar.gz", MacOSX),
+    ).validate().insert()
+  }
 }

--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -405,7 +405,25 @@ class JavaMigrations {
     List(
       Version("java", "11.0.2-j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_x64_linux_openj9_11.0.2_9_openj9-0.12.0.tar.gz", Linux64),
       Version("java", "11.0.2-j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_x64_windows_openj9_11.0.2_9_openj9-0.12.0.zip", Windows),
-      Version("java", "11.0.2-j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_x64_mac_openj9_11.0.2_9_openj9-0.12.0.tar.gz", MacOSX),
+      Version("java", "11.0.2-j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_x64_mac_openj9_11.0.2_9_openj9-0.12.0.tar.gz", MacOSX)
+    ).validate().insert()
+  }
+
+  @ChangeSet(order = "083", id = "083-add_adoptopenjdk-hs_8_0_202", author = "joschi")
+  def migrate083(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "8.0.202-hs-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u202-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u202b08.tar.gz", Linux64),
+      Version("java", "8.0.202-hs-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u202-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u202b08.zip", Windows),
+      Version("java", "8.0.202-hs-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u202-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u202b08.tar.gz", MacOSX)
+    ).validate().insert()
+  }
+
+  @ChangeSet(order = "084", id = "084-add_adoptopenjdk-hs_11_0_2", author = "joschi")
+  def migrate084(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "11.0.2-hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.2_9.tar.gz", Linux64),
+      Version("java", "11.0.2-hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_x64_windows_hotspot_11.0.2_9.zip", Windows),
+      Version("java", "11.0.2-hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_x64_mac_hotspot_11.0.2_9.tar.gz", MacOSX)
     ).validate().insert()
   }
 }


### PR DESCRIPTION
This PR picks up the discussion in #49 and uses the naming schema suggested by @munukutla in his last comment: https://github.com/sdkman/sdkman-db-migrations/pull/49/files#r237146134

The OpenJ9 project itself links to the AdoptOpenJDK website for binary downloads, so using the suffix "-openj9" to identify AdoptOpenJDK OpenJDK builds with OpenJ9 should be fine.

Refs sdkman/sdkman-db-migrations#49
Refs eclipse/openj9#1924