### PR TITLE
Add SapMachine 11.0.2 for Linux, Windows and MacOS.

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -476,6 +476,5 @@ class JavaMigrations {
       Version("java", "11.0.2-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.2/sapmachine-jdk-11.0.2_windows-x64_bin.zip", Windows))
       .validate()
       .insert()
-    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.2-sapmachine", _))
   }
 }

--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -468,4 +468,14 @@ class JavaMigrations {
       .insert()
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "13.ea.02-open", _))
   }
+  @ChangeSet(order = "089", id = "089-add_sapmachine_java_11.0.2 author = "msailer")
+  def migrate089(implicit db: MongoDatabase): Unit = {
+    List(
+      Version("java", "11.0.2-sapmachine", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.2/sapmachine-jdk-11.0.2_linux-x64_bin.tar.gz", Linux64),
+      Version("java", "11.0.2-sapmachine", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.2/sapmachine-jdk-11.0.2_osx-x64_bin.tar.gz", MacOSX),
+      Version("java", "11.0.2-sapmachine", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.2/sapmachine-jdk-11.0.2_windows-x64_bin.zip", Windows))
+      .validate()
+      .insert()
+    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.2-sapmachine", _))
+  }
 }

--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -471,9 +471,9 @@ class JavaMigrations {
   @ChangeSet(order = "089", id = "089-add_sapmachine_java_11.0.2 author = "msailer")
   def migrate089(implicit db: MongoDatabase): Unit = {
     List(
-      Version("java", "11.0.2-sapmachine", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.2/sapmachine-jdk-11.0.2_linux-x64_bin.tar.gz", Linux64),
-      Version("java", "11.0.2-sapmachine", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.2/sapmachine-jdk-11.0.2_osx-x64_bin.tar.gz", MacOSX),
-      Version("java", "11.0.2-sapmachine", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.2/sapmachine-jdk-11.0.2_windows-x64_bin.zip", Windows))
+      Version("java", "11.0.2-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.2/sapmachine-jdk-11.0.2_linux-x64_bin.tar.gz", Linux64),
+      Version("java", "11.0.2-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.2/sapmachine-jdk-11.0.2_osx-x64_bin.tar.gz", MacOSX),
+      Version("java", "11.0.2-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.2/sapmachine-jdk-11.0.2_windows-x64_bin.zip", Windows))
       .validate()
       .insert()
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.2-sapmachine", _))


### PR DESCRIPTION
Adding SapMachine 11.0.2 (LTS) release for Linux, Windows and MacOS. 

Question: SapMachine does also support Linux on PowerPC (Little and Big Endian), could this be of interest, too? Is sdkman supported on PowerPC? If so, I can add a few lines...

Also, is the suffix "sapmachine" fine or would you like to have something shorter? 

Thanks for your help and supporting SapMachine in sdkman! 