### PR TITLE
Remove Java 9 and 10 and old GraalVM

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/CleanupMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/CleanupMigrations.scala
@@ -46,4 +46,59 @@ class CleanupMigrations {
   def migrate009(implicit db: MongoDatabase) =
     Seq(Linux32, Linux64, MacOSX, Windows)
       .foreach(platform => removeVersion("java", "8.0.201-oracle", platform))
+
+  @ChangeSet(order = "010", id = "010-remove-java-9.0.4-open", author = "jorsol")
+  def migrate010(implicit db: MongoDatabase) =
+    Seq(Linux32, Linux64, MacOSX, Windows)
+      .foreach(platform => removeVersion("java", "9.0.4-open", platform))
+
+  @ChangeSet(order = "011", id = "011-remove-java-9.0.7-zulu", author = "jorsol")
+  def migrate011(implicit db: MongoDatabase) =
+    Seq(Linux32, Linux64, MacOSX, Windows)
+      .foreach(platform => removeVersion("java", "9.0.7-zulu", platform))
+
+  @ChangeSet(order = "012", id = "012-remove-java-10.0.2-open", author = "jorsol")
+  def migrate012(implicit db: MongoDatabase) =
+    Seq(Linux32, Linux64, MacOSX, Windows)
+      .foreach(platform => removeVersion("java", "10.0.2-open", platform))
+
+  @ChangeSet(order = "013", id = "013-remove-java-10.0.2-zulu", author = "jorsol")
+  def migrate013(implicit db: MongoDatabase) =
+    Seq(Linux32, Linux64, MacOSX, Windows)
+      .foreach(platform => removeVersion("java", "10.0.2-zulu", platform))
+
+  @ChangeSet(order = "014", id = "014-remove-java-1.0.0-rc-8-grl", author = "jorsol")
+  def migrate014(implicit db: MongoDatabase) =
+    Seq(Linux32, Linux64, MacOSX, Windows)
+      .foreach(platform => removeVersion("java", "1.0.0-rc-8-grl", platform))
+
+  @ChangeSet(order = "015", id = "015-remove-java-1.0.0-rc-9-grl", author = "jorsol")
+  def migrate015(implicit db: MongoDatabase) =
+    Seq(Linux32, Linux64, MacOSX, Windows)
+      .foreach(platform => removeVersion("java", "1.0.0-rc-9-grl", platform))
+
+  @ChangeSet(order = "016", id = "016-remove-java-1.0.0-rc-10-grl", author = "jorsol")
+  def migrate016(implicit db: MongoDatabase) =
+    Seq(Linux32, Linux64, MacOSX, Windows)
+      .foreach(platform => removeVersion("java", "1.0.0-rc-10-grl", platform))
+
+  @ChangeSet(order = "017", id = "017-remove-java-1.0.0-rc-11-grl", author = "jorsol")
+  def migrate017(implicit db: MongoDatabase) =
+    Seq(Linux32, Linux64, MacOSX, Windows)
+      .foreach(platform => removeVersion("java", "1.0.0-rc-11-grl", platform))
+
+  @ChangeSet(order = "018", id = "018-remove-java-1.0.0-rc-12-grl", author = "jorsol")
+  def migrate018(implicit db: MongoDatabase) =
+    Seq(Linux32, Linux64, MacOSX, Windows)
+      .foreach(platform => removeVersion("java", "1.0.0-rc-12-grl", platform))
+
+  @ChangeSet(order = "019", id = "019-remove-java-1.0.0-rc-13-grl", author = "jorsol")
+  def migrate019(implicit db: MongoDatabase) =
+    Seq(Linux32, Linux64, MacOSX, Windows)
+      .foreach(platform => removeVersion("java", "1.0.0-rc-13-grl", platform))
+
+  @ChangeSet(order = "020", id = "020-remove-java-1.0.0-rc-14-grl", author = "jorsol")
+  def migrate020(implicit db: MongoDatabase) =
+    Seq(Linux32, Linux64, MacOSX, Windows)
+      .foreach(platform => removeVersion("java", "1.0.0-rc-14-grl", platform))
 }


### PR DESCRIPTION
Java 9 and Java 10 (zulu and open variants) are now out of support, so they should not be available.

GraalVM < 1.0.0-rc-15-grl should also be removed, new versions are just added but not removed the previous one.