### PR TITLE
 Add new AdoptOpenJDK updates for 8 and 11 for OpenJ9 and Hotspot variants

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -807,7 +807,7 @@ class JavaMigrations {
       Version("java", "8.0.202.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/OpenJDK8U-jdk_x64_windows_hotspot_8u212b03.zip", Windows),
       Version("java", "8.0.202.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/OpenJDK8U-jdk_x64_mac_hotspot_8u212b03.tar.gz", MacOSX)
     ).validate().insert()
-    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", vwrsion = "8.0.202.hs-adpt", platform))
+    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "8.0.202.hs-adpt", platform))
   }
 
   @ChangeSet(order = "121", id = "121-add_adoptopenjdk-hs_11_0_3", author = "jaegerk")

--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -787,7 +787,7 @@ class JavaMigrations {
       Version("java", "8.0.212.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03_openj9-0.14.0/OpenJDK8U-jdk_x64_windows_openj9_8u212b03_openj9-0.14.0.zip", Windows),
       Version("java", "8.0.212.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03_openj9-0.14.0/OpenJDK8U-jdk_x64_mac_openj9_8u212b03_openj9-0.14.0.tar.gz", MacOSX)
     ).validate().insert()
-    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "8.0.202.j9-adpt", platform))
+    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "8.0.202.j9-adpt", _))
   }
 
   @ChangeSet(order = "119", id = "119-add_adoptopenjdk-j9_11_0_3", author = "jaegerk")
@@ -797,7 +797,7 @@ class JavaMigrations {
       Version("java", "11.0.3.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.0/OpenJDK11U-jdk_x64_windows_openj9_11.0.3_7_openj9-0.14.0.zip", Windows),
       Version("java", "11.0.3.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.0/OpenJDK11U-jdk_x64_mac_openj9_11.0.3_7_openj9-0.14.0.tar.gz", MacOSX)
     ).validate().insert()
-    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "11.0.2.j9-adpt", platform))
+    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.2.j9-adpt", _))
   }
 
   @ChangeSet(order = "120", id = "120-add_adoptopenjdk-hs_8_0_212", author = "jaegerk")
@@ -807,7 +807,7 @@ class JavaMigrations {
       Version("java", "8.0.202.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/OpenJDK8U-jdk_x64_windows_hotspot_8u212b03.zip", Windows),
       Version("java", "8.0.202.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/OpenJDK8U-jdk_x64_mac_hotspot_8u212b03.tar.gz", MacOSX)
     ).validate().insert()
-    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "8.0.202.hs-adpt", platform))
+    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "8.0.202.hs-adpt", _))
   }
 
   @ChangeSet(order = "121", id = "121-add_adoptopenjdk-hs_11_0_3", author = "jaegerk")
@@ -817,7 +817,7 @@ class JavaMigrations {
       Version("java", "11.0.3.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_x64_windows_hotspot_11.0.3_7.zip", Windows),
       Version("java", "11.0.3.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_x64_mac_hotspot_11.0.3_7.tar.gz", MacOSX)
     ).validate().insert()
-    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "11.0.2.hs-adpt", platform))
+    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.2.hs-adpt", _))
   }
 
   @ChangeSet(order = "122", id = "122-add_bellsoft_8_0_212", author = "den1ska")

--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -777,7 +777,7 @@ class JavaMigrations {
       .validate()
       .insert()
     setCandidateDefault("java", "11.0.3-open")
-    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "11.0.2-open", platform))
+    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.2-open", _))
   }
   
   @ChangeSet(order = "118", id = "118-add_openj9_8_0_212", author = "jaegerk")

--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -780,7 +780,7 @@ class JavaMigrations {
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.2-open", _))
   }
   
-  @ChangeSet(order = "118", id = "118-add_adoptopenjdk-j9_8_0_212", author = "jaegerk")
+  @ChangeSet(order = "118", id = "118-add_adoptopenjdk-j9_8_0_212", author = "kjjaeger")
   def migrate118(implicit db: MongoDatabase) = {
     List(
       Version("java", "8.0.212.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03_openj9-0.14.0/OpenJDK8U-jdk_x64_linux_openj9_8u212b03_openj9-0.14.0.tar.gz", Linux64),
@@ -790,7 +790,7 @@ class JavaMigrations {
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "8.0.202.j9-adpt", _))
   }
 
-  @ChangeSet(order = "119", id = "119-add_adoptopenjdk-j9_11_0_3", author = "jaegerk")
+  @ChangeSet(order = "119", id = "119-add_adoptopenjdk-j9_11_0_3", author = "kjjaeger")
   def migrate119(implicit db: MongoDatabase) = {
     List(
       Version("java", "11.0.3.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.0/OpenJDK11U-jdk_x64_linux_openj9_11.0.3_7_openj9-0.14.0.tar.gz", Linux64),
@@ -800,7 +800,7 @@ class JavaMigrations {
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.2.j9-adpt", _))
   }
 
-  @ChangeSet(order = "120", id = "120-add_adoptopenjdk-hs_8_0_212", author = "jaegerk")
+  @ChangeSet(order = "120", id = "120-add_adoptopenjdk-hs_8_0_212", author = "kjjaeger")
   def migrate120(implicit db: MongoDatabase) = {
     List(
       Version("java", "8.0.202.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/OpenJDK8U-jdk_x64_linux_hotspot_8u212b03.tar.gz", Linux64),
@@ -810,7 +810,7 @@ class JavaMigrations {
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "8.0.202.hs-adpt", _))
   }
 
-  @ChangeSet(order = "121", id = "121-add_adoptopenjdk-hs_11_0_3", author = "jaegerk")
+  @ChangeSet(order = "121", id = "121-add_adoptopenjdk-hs_11_0_3", author = "kjjaeger")
   def migrate121(implicit db: MongoDatabase) = {
     List(
       Version("java", "11.0.3.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.3_7.tar.gz", Linux64),

--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -780,7 +780,7 @@ class JavaMigrations {
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.2-open", _))
   }
   
-  @ChangeSet(order = "118", id = "118-add_openj9_8_0_212", author = "jaegerk")
+  @ChangeSet(order = "118", id = "118-add_adoptopenjdk-j9_8_0_212", author = "jaegerk")
   def migrate118(implicit db: MongoDatabase) = {
     List(
       Version("java", "8.0.212.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03_openj9-0.14.0/OpenJDK8U-jdk_x64_linux_openj9_8u212b03_openj9-0.14.0.tar.gz", Linux64),
@@ -790,7 +790,7 @@ class JavaMigrations {
     Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "8.0.202.j9-adpt", platform))
   }
 
-  @ChangeSet(order = "119", id = "119-add_openj9_11_0_3", author = "jaegerk")
+  @ChangeSet(order = "119", id = "119-add_adoptopenjdk-j9_11_0_3", author = "jaegerk")
   def migrate119(implicit db: MongoDatabase) = {
     List(
       Version("java", "11.0.3.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.0/OpenJDK11U-jdk_x64_linux_openj9_11.0.3_7_openj9-0.14.0.tar.gz", Linux64),

--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -777,6 +777,46 @@ class JavaMigrations {
       .validate()
       .insert()
     setCandidateDefault("java", "11.0.3-open")
-    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.2-open", _))
+    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "11.0.2-open", platform))
+  }
+  
+  @ChangeSet(order = "118", id = "118-add_openj9_8_0_212", author = "jaegerk")
+  def migrate118(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "8.0.212.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03_openj9-0.14.0/OpenJDK8U-jdk_x64_linux_openj9_8u212b03_openj9-0.14.0.tar.gz", Linux64),
+      Version("java", "8.0.212.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03_openj9-0.14.0/OpenJDK8U-jdk_x64_windows_openj9_8u212b03_openj9-0.14.0.zip", Windows),
+      Version("java", "8.0.212.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03_openj9-0.14.0/OpenJDK8U-jdk_x64_mac_openj9_8u212b03_openj9-0.14.0.tar.gz", MacOSX)
+    ).validate().insert()
+    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "8.0.202.j9-adpt", platform))
+  }
+
+  @ChangeSet(order = "119", id = "119-add_openj9_11_0_3", author = "jaegerk")
+  def migrate119(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "11.0.3.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.0/OpenJDK11U-jdk_x64_linux_openj9_11.0.3_7_openj9-0.14.0.tar.gz", Linux64),
+      Version("java", "11.0.3.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.0/OpenJDK11U-jdk_x64_windows_openj9_11.0.3_7_openj9-0.14.0.zip", Windows),
+      Version("java", "11.0.3.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.0/OpenJDK11U-jdk_x64_mac_openj9_11.0.3_7_openj9-0.14.0.tar.gz", MacOSX)
+    ).validate().insert()
+    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "11.0.2.j9-adpt", platform))
+  }
+
+  @ChangeSet(order = "120", id = "120-add_adoptopenjdk-hs_8_0_212", author = "jaegerk")
+  def migrate120(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "8.0.202.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/OpenJDK8U-jdk_x64_linux_hotspot_8u212b03.tar.gz", Linux64),
+      Version("java", "8.0.202.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/OpenJDK8U-jdk_x64_windows_hotspot_8u212b03.zip", Windows),
+      Version("java", "8.0.202.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/OpenJDK8U-jdk_x64_mac_hotspot_8u212b03.tar.gz", MacOSX)
+    ).validate().insert()
+    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", vwrsion = "8.0.202.hs-adpt", platform))
+  }
+
+  @ChangeSet(order = "121", id = "121-add_adoptopenjdk-hs_11_0_3", author = "jaegerk")
+  def migrate121(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "11.0.3.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.3_7.tar.gz", Linux64),
+      Version("java", "11.0.3.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_x64_windows_hotspot_11.0.3_7.zip", Windows),
+      Version("java", "11.0.3.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_x64_mac_hotspot_11.0.3_7.tar.gz", MacOSX)
+    ).validate().insert()
+    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "11.0.2.hs-adpt", platform))
   }
 }


### PR DESCRIPTION
Add 4 updated JDKs for AdoptOpenJDK version 8 and 11 in OpenJ9 and HotSpot variants.
8.0.212.j9-adpt, 11.0.3.j9-adpt, 8.0.212.hs-adpt, and 11.0.3.hs-adpt