### PR TITLE
Adding AdoptOpenJDK 12.0.1 HotSpot for Windows

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -917,4 +917,11 @@ class JavaMigrations {
       .insert()
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "13.ea.17-open", _))
   }
+  
+  @ChangeSet(order = "134", id = "134-add_adoptopenjdk-hs-windows_12_0_1", author = "kjjaeger")
+  def migrate134(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "12.0.1.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.1%2B12/OpenJDK12U-jdk_x64_windows_hotspot_12.0.1_12.zip", Windows)
+      ).validate().insert()
+  }
 }


### PR DESCRIPTION
Adding AdoptOpenJDK version 12.0.1 HotSpot for Windows again.