### PR TITLE
Add Graal 19.0.0 and remove Graal RC14

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -962,17 +962,17 @@ class JavaMigrations {
     List(
       Version(
         candidate = "java",
-        version = "19.0.0-grl-ce",
+        version = "19.0.0-grl",
         url = "https://github.com/oracle/graal/releases/download/vm-19.0.0/graalvm-ce-linux-amd64-19.0.0.tar.gz",
         platform = Linux64),
       Version(
         candidate = "java",
-        version = "19.0.0-grl-ce",
+        version = "19.0.0-grl",
         url = "https://github.com/oracle/graal/releases/download/vm-19.0.0/graalvm-ce-darwin-amd64-19.0.0.tar.gz",
         platform = MacOSX),
       Version(
         candidate = "java",
-        version = "19.0.0-grl-ce",
+        version = "19.0.0-grl",
         url = "https://github.com/oracle/graal/releases/download/vm-19.0.0/graalvm-ce-windows-amd64-19.0.0.zip",
         platform = Windows))
       .validate()

--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -962,17 +962,17 @@ class JavaMigrations {
     List(
       Version(
         candidate = "java",
-        version = "19.0.0-graal-ce",
+        version = "19.0.0-grl-ce",
         url = "https://github.com/oracle/graal/releases/download/vm-19.0.0/graalvm-ce-linux-amd64-19.0.0.tar.gz",
         platform = Linux64),
       Version(
         candidate = "java",
-        version = "19.0.0-graal-ce",
+        version = "19.0.0-grl-ce",
         url = "https://github.com/oracle/graal/releases/download/vm-19.0.0/graalvm-ce-darwin-amd64-19.0.0.tar.gz",
         platform = MacOSX),
       Version(
         candidate = "java",
-        version = "19.0.0-graal-ce",
+        version = "19.0.0-grl-ce",
         url = "https://github.com/oracle/graal/releases/download/vm-19.0.0/graalvm-ce-windows-amd64-19.0.0.zip",
         platform = Windows))
       .validate()

--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -957,4 +957,27 @@ class JavaMigrations {
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "13.ea.19-open", _))
   }
 
+  @ChangeSet(order = "138", id = "138-add_graalvm_19_0_0", author = "ilopmar")
+  def migrate138(implicit db: MongoDatabase) = {
+    List(
+      Version(
+        candidate = "java",
+        version = "19.0.0-graal-ce",
+        url = "https://github.com/oracle/graal/releases/download/vm-19.0.0/graalvm-ce-linux-amd64-19.0.0.tar.gz",
+        platform = Linux64),
+      Version(
+        candidate = "java",
+        version = "19.0.0-graal-ce",
+        url = "https://github.com/oracle/graal/releases/download/vm-19.0.0/graalvm-ce-darwin-amd64-19.0.0.tar.gz",
+        platform = MacOSX),
+      Version(
+        candidate = "java",
+        version = "19.0.0-graal-ce",
+        url = "https://github.com/oracle/graal/releases/download/vm-19.0.0/graalvm-ce-windows-amd64-19.0.0.zip",
+        platform = Windows))
+      .validate()
+      .insert()
+    Seq(Linux64, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "1.0.0-rc-14-grl", platform))
+  }
+
 }


### PR DESCRIPTION
This PR add Graal 19.0.0 and removes old RC14. We'll keep RC15 and 16 for a while because the new one introduced some breaking changes.