### PR TITLE
Change CUBA CLI download URLs

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/CubaCliMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/CubaCliMigrations.scala
@@ -38,4 +38,26 @@ class CubaCliMigrations {
       .validate()
       .insert()
   }
+
+  @ChangeSet(order = "002", id = "002_change_versions_urls", author = "torquemada163")
+  def migration002(implicit db: MongoDatabase) =
+    Seq("1.0.1", "1.0.2", "1.0.3", "2.0.1", "2.0.2", "2.0.3", "2.0.4", "2.1.0").foreach { version =>
+
+      removeVersion("spark", version)
+      List(
+        Version(
+          candidate = "cuba",
+          version = version,
+          url = s"https://cdn.cuba-platform.com/cuba-cli/$version/cuba-cli-$version-linux.zip",
+          platform = Linux64
+        ),
+        Version(
+          candidate = "cuba",
+          version = version,
+          url = s"https://cdn.cuba-platform.com/cuba-cli/$version/cuba-cli-$version-macos.zip",
+          platform = MacOSX
+        ))
+        .validate()
+        .insert()
+    }
 }

--- a/src/main/scala/io/sdkman/changelogs/CubaCliMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/CubaCliMigrations.scala
@@ -43,7 +43,7 @@ class CubaCliMigrations {
   def migration002(implicit db: MongoDatabase) =
     Seq("1.0.1", "1.0.2", "1.0.3", "2.0.1", "2.0.2", "2.0.3", "2.0.4", "2.1.0").foreach { version =>
 
-      removeVersion("spark", version)
+      removeVersion("cuba", version)
       List(
         Version(
           candidate = "cuba",


### PR DESCRIPTION
Hi!

I'm from CUBA Platform Team.
We are migrating cuba-cli releases from Bintray to KeyCDN.

Links were in this format:
`https://cuba-platform.bintray.com/tools/cuba-cli/<VERSION>/cuba-cli-<VERSION>-linux.zip`
`https://cuba-platform.bintray.com/tools/cuba-cli/<VERSION>/cuba-cli-<VERSION>-macos.zip`

Now we have moved binaries to CDN and links look like:
`https://cdn.cuba-platform.com/cuba-cli/<VERSION>/cuba-cli-<VERSION>-linux.zip`
`https://cdn.cuba-platform.com/cuba-cli/<VERSION>/cuba-cli-<VERSION>-macos.zip`