### PR TITLE
Update default Java candidate to 11.0.4.hs-adpt

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -573,4 +573,10 @@ class JavaMigrations {
       .validate()
       .insert()
   }
+
+  @ChangeSet(order = "179", id = "179-update_java_default", author = "vpavic")
+  def migrate179(implicit db: MongoDatabase) = {
+    setCandidateDefault("java", "11.0.4.hs-adpt")
+  }
+
 }


### PR DESCRIPTION
SDKMAN currently offers `11.0.3.hs-adpt` as default Java candidate:

```bash
$ sdk ug

Upgrade:
java (7.0.232-zulu, 12.0.1.j9-adpt, 13.ea.30-open, 11.0.4.j9-adpt, 11.0.4.hs-adpt, 19.1.1-grl, 6.0.119-zulu, 14.ea.6-open, 8.0.222.hs-adpt, 8.0.222.j9-adpt, 12.0.1.hs-adpt < 11.0.3.hs-adpt)

Upgrade candidate(s) and set latest version(s) as default? (Y/n):
```

This PR updates default Java candidate to `11.0.4.hs-adpt`.