### PR TITLE
AdoptOpenJDK 8.0.232, 11.05, 13.01

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -89,62 +89,6 @@ class JavaMigrations {
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.1-open", _))
   }
 
-  @ChangeSet(order = "129", id = "129-add_adoptopenjdk-hs_11_0_3", author = "eddumelendez")
-  def migrate129(implicit db: MongoDatabase) = {
-    List(
-      Version("java", "11.0.3.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.3_7.tar.gz", Linux64),
-      Version("java", "11.0.3.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_x64_mac_hotspot_11.0.3_7.tar.gz", MacOSX),
-      Version("java", "11.0.3.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_x64_windows_hotspot_11.0.3_7.zip", Windows))
-      .validate()
-      .insert()
-    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.2.hs-adpt", _))
-  }
-
-  @ChangeSet(order = "130", id = "130-add_openj9_11_0_3", author = "eddumelendez")
-  def migrate130(implicit db: MongoDatabase) = {
-    List(
-      Version("java", "11.0.3.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.0/OpenJDK11U-jdk_x64_linux_openj9_11.0.3_7_openj9-0.14.0.tar.gz", Linux64),
-      Version("java", "11.0.3.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.0/OpenJDK11U-jdk_x64_windows_openj9_11.0.3_7_openj9-0.14.0.zip", MacOSX),
-      Version("java", "11.0.3.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.0/OpenJDK11U-jdk_x64_mac_openj9_11.0.3_7_openj9-0.14.0.tar.gz", Windows))
-      .validate()
-      .insert()
-    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.2.j9-adpt", _))
-  }
-
-  @ChangeSet(order = "131", id = "131-add_adoptopenjdk-j9_12_0_1", author = "jaegerk")
-  def migrate131(implicit db: MongoDatabase) = {
-    List(
-      Version("java", "12.0.1.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.1%2B12_openj9-0.14.1/OpenJDK12U-jdk_x64_linux_openj9_12.0.1_12_openj9-0.14.1.tar.gz", Linux64),
-      Version("java", "12.0.1.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.1%2B12_openj9-0.14.1/OpenJDK12U-jdk_x64_windows_openj9_12.0.1_12_openj9-0.14.1.zip", Windows),
-      Version("java", "12.0.1.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.1%2B12_openj9-0.14.1/OpenJDK12U-jdk_x64_mac_openj9_12.0.1_12_openj9-0.14.1.tar.gz", MacOSX)
-    ).validate().insert()
-  }
-
-  @ChangeSet(order = "132", id = "132-add_adoptopenjdk-hs_12_0_1", author = "jaegerk")
-  def migrate132(implicit db: MongoDatabase) = {
-    List(
-      Version("java", "12.0.1.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.1%2B12/OpenJDK12U-jdk_x64_linux_hotspot_12.0.1_12.tar.gz", Linux64),
-      Version("java", "12.0.1.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.1%2B12/OpenJDK12U-jdk_x64_mac_hotspot_12.0.1_12.tar.gz", MacOSX)
-    ).validate().insert()
-  }
-
-  @ChangeSet(order = "134", id = "134-add_adoptopenjdk-hs-windows_12_0_1", author = "kjjaeger")
-  def migrate134(implicit db: MongoDatabase) =
-    Version("java", "12.0.1.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.1%2B12/OpenJDK12U-jdk_x64_windows_hotspot_12.0.1_12.zip", Windows)
-      .validate().insert()
-
-  @ChangeSet(order = "135", id = "135-fix_broken_adopt_openjdk_j9_11_0_3", author = "marc0der")
-  def migrate135(implicit db: MongoDatabase) = {
-    val candidate = "java"
-    val version = "11.0.3.j9-adpt"
-    Seq(Windows, MacOSX).foreach(p => removeVersion(candidate, version, p))
-    List(
-      Version(candidate, version, "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.0/OpenJDK11U-jdk_x64_windows_openj9_11.0.3_7_openj9-0.14.0.zip", Windows),
-      Version(candidate, version, "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.0/OpenJDK11U-jdk_x64_mac_openj9_11.0.3_7_openj9-0.14.0.tar.gz", MacOSX))
-      .validate()
-      .insert()
-  }
-
   @ChangeSet(order = "138", id = "138-add_graalvm_19_0_0", author = "ilopmar")
   def migrate138(implicit db: MongoDatabase) = {
     List(
@@ -293,28 +237,6 @@ class JavaMigrations {
       Version("java", "12.0.2-librca", "https://download.bell-sw.com/java/12.0.2/bellsoft-jdk12.0.2-macos-amd64.zip", MacOSX, Some(Liberica))
     ).validate().insert()
     Seq(Linux32, Linux64, MacOSX, Windows).foreach(removeVersion("java", "12.0.1-librca", _))
-  }
-
-  @ChangeSet(order = "174", id = "174-add_adoptopenjdk-hs_11_0_4", author = "jschalanda")
-  def migrate174(implicit db: MongoDatabase) = {
-    List(
-      Version("java", "11.0.4.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4+11/OpenJDK11U-jdk_x64_linux_hotspot_11.0.4_11.tar.gz", Linux64, Some(AdoptOpenJDK)),
-      Version("java", "11.0.4.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4+11/OpenJDK11U-jdk_x64_mac_hotspot_11.0.4_11.tar.gz", MacOSX, Some(AdoptOpenJDK)),
-      Version("java", "11.0.4.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4+11/OpenJDK11U-jdk_x64_windows_hotspot_11.0.4_11.zip", Windows, Some(AdoptOpenJDK)))
-      .validate()
-      .insert()
-    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.3.hs-adpt", _))
-  }
-
-  @ChangeSet(order = "175", id = "175-add_adoptopenjdk-j9_11_0_4", author = "jschalanda")
-  def migrate175(implicit db: MongoDatabase) = {
-    List(
-      Version("java", "11.0.4.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4+11_openj9-0.15.1/OpenJDK11U-jdk_x64_linux_openj9_11.0.4_11_openj9-0.15.1.tar.gz", Linux64, Some(AdoptOpenJDK)),
-      Version("java", "11.0.4.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4+11_openj9-0.15.1/OpenJDK11U-jdk_x64_mac_openj9_11.0.4_11_openj9-0.15.1.tar.gz", MacOSX, Some(AdoptOpenJDK)),
-      Version("java", "11.0.4.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4+11_openj9-0.15.1/OpenJDK11U-jdk_x64_windows_openj9_11.0.4_11_openj9-0.15.1.zip", Windows, Some(AdoptOpenJDK)))
-      .validate()
-      .insert()
-    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.3.j9-adpt", _))
   }
 
   @ChangeSet(order = "178", id = "178-restore_graalvm_19_0", author = "dsyer")

--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -358,30 +358,6 @@ class JavaMigrations {
       .insert()
   }
 
-  @ChangeSet(order = "192", id = "192-add_13.0.0.hs-adpt", author = "vpavic")
-  def migrate192(implicit db: MongoDatabase): Unit = {
-    val candidate = "java"
-    val newVersion = "13.0.0.hs-adpt"
-    List(
-      Version(candidate, newVersion, "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/OpenJDK13U-jdk_x64_linux_hotspot_13_33.tar.gz", Linux64, Some(AdoptOpenJDK)),
-      Version(candidate, newVersion, "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/OpenJDK13U-jdk_x64_mac_hotspot_13_33.tar.gz", MacOSX, Some(AdoptOpenJDK)),
-      Version(candidate, newVersion, "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/OpenJDK13U-jdk_x64_windows_hotspot_13_33.zip", Windows, Some(AdoptOpenJDK)))
-      .validate()
-      .insert()
-  }
-
-  @ChangeSet(order = "193", id = "193-add_13.0.0.j9-adpt", author = "vpavic")
-  def migrate193(implicit db: MongoDatabase): Unit = {
-    val candidate = "java"
-    val newVersion = "13.0.0.j9-adpt"
-    List(
-      Version(candidate, newVersion, "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33_openj9-0.16.0/OpenJDK13U-jdk_x64_linux_openj9_13_33_openj9-0.16.0.tar.gz", Linux64, Some(AdoptOpenJDK)),
-      Version(candidate, newVersion, "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33_openj9-0.16.0/OpenJDK13U-jdk_x64_mac_openj9_13_33_openj9-0.16.0.tar.gz", MacOSX, Some(AdoptOpenJDK)),
-      Version(candidate, newVersion, "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33_openj9-0.16.0/OpenJDK13U-jdk_x64_windows_openj9_13_33_openj9-0.16.0.zip", Windows, Some(AdoptOpenJDK)))
-      .validate()
-      .insert()
-  }
-
   @ChangeSet(order = "195", id = "195-add_openjdk_java_13.0.1", author = "eddumelendez")
   def migrate195(implicit db: MongoDatabase) = {
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "13.0.0-open", _))
@@ -610,4 +586,25 @@ class JavaMigrations {
       .insert()
   }
 
+  @ChangeSet(order = "216", id = "216-add_adoptopenjdk-hs_13_0_1", author = "timw")
+  def migrate209(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "13.0.1.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.1%2B9/OpenJDK13U-jdk_x64_linux_hotspot_13.0.1_9.tar.gz", Linux64, Some(AdoptOpenJDK)),
+      Version("java", "13.0.1.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.1%2B9/OpenJDK13U-jdk_x64_windows_hotspot_13.0.1_9.zip", MacOSX, Some(AdoptOpenJDK)),
+      Version("java", "13.0.1.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.1%2B9/OpenJDK13U-jdk_x64_mac_hotspot_13.0.1_9.tar.gz", Windows, Some(AdoptOpenJDK)))
+      .validate()
+      .insert()
+    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "13.0.0.hs-adpt", _))
+  }
+
+  @ChangeSet(order = "217", id = "217-add_adoptopenjdk-j9_13_0_1", author = "timw")
+  def migrate210(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "13.0.1.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.1%2B9_openj9-0.17.0/OpenJDK13U-jdk_x64_linux_openj9_13.0.1_9_openj9-0.17.0.tar.gz", Linux64, Some(AdoptOpenJDK)),
+      Version("java", "13.0.1.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.1%2B9_openj9-0.17.0/OpenJDK13U-jdk_x64_mac_openj9_13.0.1_9_openj9-0.17.0.tar.gz", MacOSX, Some(AdoptOpenJDK)),
+      Version("java", "13.0.1.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.1%2B9_openj9-0.17.0/OpenJDK13U-jdk_x64_windows_openj9_13.0.1_9_openj9-0.17.0.zip", Windows, Some(AdoptOpenJDK)))
+      .validate()
+      .insert()
+    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "13.0.0.j9-adpt", _))
+  }
 }

--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -89,28 +89,6 @@ class JavaMigrations {
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.1-open", _))
   }
 
-  @ChangeSet(order = "127", id = "127-add_adoptopenjdk-hs_8_0_212", author = "eddumelendez")
-  def migrate127(implicit db: MongoDatabase) = {
-    List(
-      Version("java", "8.0.212.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/OpenJDK8U-jdk_x64_linux_hotspot_8u212b03.tar.gz", Linux64),
-      Version("java", "8.0.212.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/OpenJDK8U-jdk_x64_mac_hotspot_8u212b03.tar.gz", MacOSX),
-      Version("java", "8.0.212.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/OpenJDK8U-jdk_x64_windows_hotspot_8u212b03.zip", Windows))
-      .validate()
-      .insert()
-    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "8.0.202.hs-adpt", _))
-  }
-
-  @ChangeSet(order = "128", id = "128-add_openj9_8_0_212", author = "eddumelendez")
-  def migrate128(implicit db: MongoDatabase) = {
-    List(
-      Version("java", "8.0.212.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03_openj9-0.14.0/OpenJDK8U-jdk_x64_linux_openj9_8u212b03_openj9-0.14.0.tar.gz", Linux64),
-      Version("java", "8.0.212.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03_openj9-0.14.0/OpenJDK8U-jdk_x64_mac_openj9_8u212b03_openj9-0.14.0.tar.gz", MacOSX),
-      Version("java", "8.0.212.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03_openj9-0.14.0/OpenJDK8U-jdk_x64_windows_openj9_8u212b03_openj9-0.14.0.zip", Windows))
-      .validate()
-      .insert()
-    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "8.0.202.j9-adpt", _))
-  }
-
   @ChangeSet(order = "129", id = "129-add_adoptopenjdk-hs_11_0_3", author = "eddumelendez")
   def migrate129(implicit db: MongoDatabase) = {
     List(
@@ -337,28 +315,6 @@ class JavaMigrations {
       .validate()
       .insert()
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.3.j9-adpt", _))
-  }
-
-  @ChangeSet(order = "176", id = "176-add_adoptopenjdk-hs_8_0_222", author = "jschalanda")
-  def migrate176(implicit db: MongoDatabase) = {
-    List(
-      Version("java", "8.0.222.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u222b10.tar.gz", Linux64, Some(AdoptOpenJDK)),
-      Version("java", "8.0.222.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10/OpenJDK8U-jdk_x64_mac_hotspot_8u222b10.tar.gz", MacOSX, Some(AdoptOpenJDK)),
-      Version("java", "8.0.222.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10/OpenJDK8U-jdk_x64_windows_hotspot_8u222b10.zip", Windows, Some(AdoptOpenJDK)))
-      .validate()
-      .insert()
-    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "8.0.212.hs-adpt", _))
-  }
-
-  @ChangeSet(order = "177", id = "177-add_adoptopenjdk-j9_8_0_222", author = "jschalanda")
-  def migrate177(implicit db: MongoDatabase) = {
-    List(
-      Version("java", "8.0.222.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jdk_x64_linux_openj9_8u222b10_openj9-0.15.1.tar.gz", Linux64, Some(AdoptOpenJDK)),
-      Version("java", "8.0.222.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jdk_x64_mac_openj9_8u222b10_openj9-0.15.1.tar.gz", MacOSX, Some(AdoptOpenJDK)),
-      Version("java", "8.0.222.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jdk_x64_windows_openj9_8u222b10_openj9-0.15.1.zip", Windows, Some(AdoptOpenJDK)))
-      .validate()
-      .insert()
-    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "8.0.212.j9-adpt", _))
   }
 
   @ChangeSet(order = "178", id = "178-restore_graalvm_19_0", author = "dsyer")


### PR DESCRIPTION
Hotspot and J9 builds of AdoptOpenJDK 8.0.232, 11.05, 13.01

Also cleaned up superceded AdoptOpenJDK sdk defs that were removed, but left in code, by previous revisions.