### PR TITLE
Bump same JDKs

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -492,15 +492,15 @@ class JavaMigrations {
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "8.0.222.j9-adpt", _))
   }
 
-  @ChangeSet(order = "207", id = "207-add_adoptopenjdk-hs_11_0_5", author = "andrebrait")
+  @ChangeSet(order = "207", id = "207-add_adoptopenjdk-hs_11_0_6", author = "andrebrait")
   def migrate207(implicit db: MongoDatabase) = {
     List(
-      Version("java", "11.0.5.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.5+10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.5_10.tar.gz", Linux64, Some(AdoptOpenJDK)),
-      Version("java", "11.0.5.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.5+10/OpenJDK11U-jdk_x64_mac_hotspot_11.0.5_10.tar.gz", MacOSX, Some(AdoptOpenJDK)),
-      Version("java", "11.0.5.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.5+10/OpenJDK11U-jdk_x64_windows_hotspot_11.0.5_10.zip", Windows, Some(AdoptOpenJDK)))
+      Version("java", "11.0.6.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6+10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.6_10.tar.gz", Linux64, Some(AdoptOpenJDK)),
+      Version("java", "11.0.6.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6+10/OpenJDK11U-jdk_x64_mac_hotspot_11.0.6_10.tar.gz", MacOSX, Some(AdoptOpenJDK)),
+      Version("java", "11.0.6.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6+10/OpenJDK11U-jdk_x64_windows_hotspot_11.0.6_10.zip", Windows, Some(AdoptOpenJDK)))
       .validate()
       .insert()
-    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.4.hs-adpt", _))
+    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.5.hs-adpt", _))
   }
 
   @ChangeSet(order = "208", id = "208-add_adoptopenjdk-j9_11_0_5", author = "andrebrait")

--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -369,17 +369,6 @@ class JavaMigrations {
       .insert()
   }
 
-//  @ChangeSet(order = "196", id = "196-add_openjdk_java_14-ea-18", author = "eddumelendez")
-//  def migrate196(implicit db: MongoDatabase): Unit = {
-//    List(
-//      Version("java", "14.ea.18-open", "https://download.java.net/java/early_access/jdk14/18/GPL/openjdk-14-ea+18_linux-x64_bin.tar.gz", Linux64, Some(OpenJDK)),
-//      Version("java", "14.ea.18-open", "https://download.java.net/java/early_access/jdk14/18/GPL/openjdk-14-ea+18_osx-x64_bin.tar.gz", MacOSX, Some(OpenJDK)),
-//      Version("java", "14.ea.18-open", "https://download.java.net/java/early_access/jdk14/18/GPL/openjdk-14-ea+18_windows-x64_bin.zip", Windows, Some(OpenJDK)))
-//      .validate()
-//      .insert()
-//    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "14.ea.17-open", _))
-//  }
-
   @ChangeSet(order = "197", id = "197-add_zulu_7_0_242", author = "jorsol")
   def migrate197(implicit db: MongoDatabase) = {
     List(

--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -369,16 +369,16 @@ class JavaMigrations {
       .insert()
   }
 
-  @ChangeSet(order = "196", id = "196-add_openjdk_java_14-ea-18", author = "eddumelendez")
-  def migrate196(implicit db: MongoDatabase): Unit = {
-    List(
-      Version("java", "14.ea.18-open", "https://download.java.net/java/early_access/jdk14/18/GPL/openjdk-14-ea+18_linux-x64_bin.tar.gz", Linux64, Some(OpenJDK)),
-      Version("java", "14.ea.18-open", "https://download.java.net/java/early_access/jdk14/18/GPL/openjdk-14-ea+18_osx-x64_bin.tar.gz", MacOSX, Some(OpenJDK)),
-      Version("java", "14.ea.18-open", "https://download.java.net/java/early_access/jdk14/18/GPL/openjdk-14-ea+18_windows-x64_bin.zip", Windows, Some(OpenJDK)))
-      .validate()
-      .insert()
-    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "14.ea.17-open", _))
-  }
+//  @ChangeSet(order = "196", id = "196-add_openjdk_java_14-ea-18", author = "eddumelendez")
+//  def migrate196(implicit db: MongoDatabase): Unit = {
+//    List(
+//      Version("java", "14.ea.18-open", "https://download.java.net/java/early_access/jdk14/18/GPL/openjdk-14-ea+18_linux-x64_bin.tar.gz", Linux64, Some(OpenJDK)),
+//      Version("java", "14.ea.18-open", "https://download.java.net/java/early_access/jdk14/18/GPL/openjdk-14-ea+18_osx-x64_bin.tar.gz", MacOSX, Some(OpenJDK)),
+//      Version("java", "14.ea.18-open", "https://download.java.net/java/early_access/jdk14/18/GPL/openjdk-14-ea+18_windows-x64_bin.zip", Windows, Some(OpenJDK)))
+//      .validate()
+//      .insert()
+//    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "14.ea.17-open", _))
+//  }
 
   @ChangeSet(order = "197", id = "197-add_zulu_7_0_242", author = "jorsol")
   def migrate197(implicit db: MongoDatabase) = {

--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -492,15 +492,15 @@ class JavaMigrations {
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "8.0.222.j9-adpt", _))
   }
 
-  @ChangeSet(order = "207", id = "207-add_adoptopenjdk-hs_11_0_6", author = "andrebrait")
+  @ChangeSet(order = "207", id = "207-add_adoptopenjdk-hs_11_0_5", author = "andrebrait")
   def migrate207(implicit db: MongoDatabase) = {
     List(
-      Version("java", "11.0.6.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6+10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.6_10.tar.gz", Linux64, Some(AdoptOpenJDK)),
-      Version("java", "11.0.6.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6+10/OpenJDK11U-jdk_x64_mac_hotspot_11.0.6_10.tar.gz", MacOSX, Some(AdoptOpenJDK)),
-      Version("java", "11.0.6.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6+10/OpenJDK11U-jdk_x64_windows_hotspot_11.0.6_10.zip", Windows, Some(AdoptOpenJDK)))
+      Version("java", "11.0.5.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.5+10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.5_10.tar.gz", Linux64, Some(AdoptOpenJDK)),
+      Version("java", "11.0.5.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.5+10/OpenJDK11U-jdk_x64_mac_hotspot_11.0.5_10.tar.gz", MacOSX, Some(AdoptOpenJDK)),
+      Version("java", "11.0.5.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.5+10/OpenJDK11U-jdk_x64_windows_hotspot_11.0.5_10.zip", Windows, Some(AdoptOpenJDK)))
       .validate()
       .insert()
-    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.5.hs-adpt", _))
+    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.4.hs-adpt", _))
   }
 
   @ChangeSet(order = "208", id = "208-add_adoptopenjdk-j9_11_0_5", author = "andrebrait")

--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -208,14 +208,14 @@ class JavaMigrations {
     Seq(Linux64, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "19.1.0-grl", platform))
   }
 
-  @ChangeSet(order = "165", id = "165-add_sapmchn_11_0_4", author = "jorsol")
+  @ChangeSet(order = "165", id = "165-add_sapmchn_11_0_6", author = "jorsol")
   def migrate165(implicit db: MongoDatabase) = {
     List(
-      Version("java", "11.0.4-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.4/sapmachine-jdk-11.0.4_linux-x64_bin.tar.gz", Linux64, Some(SAP)),
-      Version("java", "11.0.4-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.4/sapmachine-jdk-11.0.4_windows-x64_bin.zip", Windows, Some(SAP)),
-      Version("java", "11.0.4-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.4/sapmachine-jdk-11.0.4_osx-x64_bin.tar.gz", MacOSX, Some(SAP))
+      Version("java", "11.0.6-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.6/sapmachine-jdk-11.0.6_linux-x64_bin.tar.gz", Linux64, Some(SAP)),
+      Version("java", "11.0.6-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.6/sapmachine-jdk-11.0.6_windows-x64_bin.zip", Windows, Some(SAP)),
+      Version("java", "11.0.6-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.6/sapmachine-jdk-11.0.6_osx-x64_bin.tar.gz", MacOSX, Some(SAP))
     ).validate().insert()
-    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "11.0.3-sapmchn", platform))
+    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "11.0.4-sapmchn", platform))
   }
 
   @ChangeSet(order = "166", id = "166-add_sapmchn_12_0_2", author = "jorsol")
@@ -358,13 +358,13 @@ class JavaMigrations {
       .insert()
   }
 
-  @ChangeSet(order = "195", id = "195-add_openjdk_java_13.0.1", author = "eddumelendez")
+  @ChangeSet(order = "195", id = "195-add_openjdk_java_13.0.2", author = "eddumelendez")
   def migrate195(implicit db: MongoDatabase) = {
-    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "13.0.0-open", _))
+    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "13.0.1-open", _))
     List(
-      Version("java", "13.0.1-open", "https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_linux-x64_bin.tar.gz", Linux64, Some(OpenJDK)),
-      Version("java", "13.0.1-open", "https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_osx-x64_bin.tar.gz", MacOSX, Some(OpenJDK)),
-      Version("java", "13.0.1-open", "https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_windows-x64_bin.zip", Windows, Some(OpenJDK)))
+      Version("java", "13.0.2-open", "https://download.java.net/java/GA/jdk13.0.2/d4173c853231432d94f001e99d882ca7/8/GPL/openjdk-13.0.2_linux-x64_bin.tar.gz", Linux64, Some(OpenJDK)),
+      Version("java", "13.0.2-open", "https://download.java.net/java/GA/jdk13.0.2/d4173c853231432d94f001e99d882ca7/8/GPL/openjdk-13.0.2_osx-x64_bin.tar.gz", MacOSX, Some(OpenJDK)),
+      Version("java", "13.0.2-open", "https://download.java.net/java/GA/jdk13.0.2/d4173c853231432d94f001e99d882ca7/8/GPL/openjdk-13.0.2_windows-x64_bin.zip", Windows, Some(OpenJDK)))
       .validate()
       .insert()
   }
@@ -389,34 +389,34 @@ class JavaMigrations {
     Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "7.0.232-zulu", platform))
   }
 
-  @ChangeSet(order = "198", id = "198-add_zulu_8_0_232", author = "jorsol")
+  @ChangeSet(order = "198", id = "198-add_zulu_8_0_242", author = "jorsol")
   def migrate198(implicit db: MongoDatabase) = {
     List(
-      Version("java", "8.0.232-zulu", "https://cdn.azul.com/zulu/bin/zulu8.42.0.21-ca-jdk8.0.232-linux_x64.tar.gz", Linux64, Some(Zulu)),
-      Version("java", "8.0.232-zulu", "https://cdn.azul.com/zulu/bin/zulu8.42.0.21-ca-jdk8.0.232-win_x64.zip", Windows, Some(Zulu)),
-      Version("java", "8.0.232-zulu", "https://cdn.azul.com/zulu/bin/zulu8.42.0.21-ca-jdk8.0.232-macosx_x64.tar.gz", MacOSX, Some(Zulu))
+      Version("java", "8.0.242-zulu", "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-linux_x64.tar.gz", Linux64, Some(Zulu)),
+      Version("java", "8.0.242-zulu", "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-win_x64.zip", Windows, Some(Zulu)),
+      Version("java", "8.0.242-zulu", "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-macosx_x64.tar.gz", MacOSX, Some(Zulu))
     ).validate().insert()
     Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "8.0.222-zulu", platform))
   }
 
-  @ChangeSet(order = "199", id = "199-add_zulu_11_0_5", author = "jorsol")
+  @ChangeSet(order = "199", id = "199-add_zulu_11_0_6", author = "jorsol")
   def migrate199(implicit db: MongoDatabase) = {
     List(
-      Version("java", "11.0.5-zulu", "https://cdn.azul.com/zulu/bin/zulu11.35.13-ca-jdk11.0.5-linux_x64.tar.gz", Linux64, Some(Zulu)),
-      Version("java", "11.0.5-zulu", "https://cdn.azul.com/zulu/bin/zulu11.35.13-ca-jdk11.0.5-win_x64.zip", Windows, Some(Zulu)),
-      Version("java", "11.0.5-zulu", "https://cdn.azul.com/zulu/bin/zulu11.35.13-ca-jdk11.0.5-macosx_x64.tar.gz", MacOSX, Some(Zulu))
+      Version("java", "11.0.6-zulu", "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz", Linux64, Some(Zulu)),
+      Version("java", "11.0.6-zulu", "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-win_x64.zip", Windows, Some(Zulu)),
+      Version("java", "11.0.6-zulu", "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz", MacOSX, Some(Zulu))
     ).validate().insert()
-    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "11.0.4-zulu", platform))
+    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "11.0.5-zulu", platform))
   }
 
-  @ChangeSet(order = "200", id = "200-add_zulu_13_0_1", author = "jorsol")
+  @ChangeSet(order = "200", id = "200-add_zulu_13_0_2", author = "jorsol")
   def migrate200(implicit db: MongoDatabase) = {
     List(
-      Version("java", "13.0.1-zulu", "https://cdn.azul.com/zulu/bin/zulu13.28.11-ca-jdk13.0.1-linux_x64.tar.gz", Linux64, Some(Zulu)),
-      Version("java", "13.0.1-zulu", "https://cdn.azul.com/zulu/bin/zulu13.28.11-ca-jdk13.0.1-win_x64.zip", Windows, Some(Zulu)),
-      Version("java", "13.0.1-zulu", "https://cdn.azul.com/zulu/bin/zulu13.28.11-ca-jdk13.0.1-macosx_x64.tar.gz", MacOSX, Some(Zulu))
+      Version("java", "13.0.2-zulu", "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-linux_x64.tar.gz", Linux64, Some(Zulu)),
+      Version("java", "13.0.2-zulu", "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-win_x64.zip", Windows, Some(Zulu)),
+      Version("java", "13.0.2-zulu", "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-macosx_x64.tar.gz", MacOSX, Some(Zulu))
     ).validate().insert()
-    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "13.0.0-zulu", platform))
+    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "13.0.1-zulu", platform))
   }
 
   @ChangeSet(order = "201", id = "201-add_graalvm_19_2_1", author = "ilopmar")
@@ -450,24 +450,24 @@ class JavaMigrations {
     Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "19.2.0.1-grl", platform))
   }
 
-  @ChangeSet(order = "203", id = "203-add_corretto_java8_update_232", author = "philiplourandos")
+  @ChangeSet(order = "203", id = "203-add_corretto_java8_update_242", author = "philiplourandos")
   def migrate203(implicit db: MongoDatabase) = {
     List(
-      Version("java", "8.0.232-amzn", "https://d3pxv6yz143wms.cloudfront.net/8.232.09.1/amazon-corretto-8.232.09.1-linux-x64.tar.gz", Linux64, Some(Amazon)),
-      Version("java", "8.0.232-amzn", "https://d3pxv6yz143wms.cloudfront.net/8.232.09.1/amazon-corretto-8.232.09.1-macosx-x64.tar.gz", MacOSX, Some(Amazon)),
-      Version("java", "8.0.232-amzn", "https://d3pxv6yz143wms.cloudfront.net/8.232.09.1/amazon-corretto-8.232.09.1-windows-x64-jdk.zip", Windows, Some(Amazon))
+      Version("java", "8.0.242-amzn", "https://corretto.aws/downloads/resources/8.242.07.1/amazon-corretto-8.242.07.1-linux-x64.tar.gz", Linux64, Some(Amazon)),
+      Version("java", "8.0.242-amzn", "https://corretto.aws/downloads/resources/8.242.07.1/amazon-corretto-8.242.07.1-macosx-x64.tar.gz", MacOSX, Some(Amazon)),
+      Version("java", "8.0.242-amzn", "https://corretto.aws/downloads/resources/8.242.07.1/amazon-corretto-8.242.07.1-windows-x64-jdk.zip", Windows, Some(Amazon))
     ).validate().insert()
-    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "8.0.222-amzn", platform))
+    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "8.0.232-amzn", platform))
   }
 
-  @ChangeSet(order = "204", id = "204-add_corretto_java11_update_5", author = "philiplourandos")
+  @ChangeSet(order = "204", id = "204-add_corretto_java11_update_6", author = "philiplourandos")
   def migrate204(implicit db: MongoDatabase) = {
     List(
-      Version("java", "11.0.5-amzn", "https://d3pxv6yz143wms.cloudfront.net/11.0.5.10.1/amazon-corretto-11.0.5.10.1-linux-x64.tar.gz", Linux64, Some(Amazon)),
-      Version("java", "11.0.5-amzn", "https://d3pxv6yz143wms.cloudfront.net/11.0.5.10.1/amazon-corretto-11.0.5.10.1-macosx-x64.tar.gz", MacOSX, Some(Amazon)),
-      Version("java", "11.0.5-amzn", "https://d3pxv6yz143wms.cloudfront.net/11.0.5.10.1/amazon-corretto-11.0.5.10.1-windows-x64.zip", Windows, Some(Amazon))
+      Version("java", "11.0.6-amzn", "https://corretto.aws/downloads/resources/11.0.6.10.1/amazon-corretto-11.0.6.10.1-linux-x64.tar.gz", Linux64, Some(Amazon)),
+      Version("java", "11.0.6-amzn", "https://corretto.aws/downloads/resources/11.0.6.10.1/amazon-corretto-11.0.6.10.1-macosx-x64.tar.gz", MacOSX, Some(Amazon)),
+      Version("java", "11.0.6-amzn", "https://corretto.aws/downloads/resources/11.0.6.10.1/amazon-corretto-11.0.6.10.1-windows-x64-jdk.zip", Windows, Some(Amazon))
     ).validate().insert()
-    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "11.0.4-amzn", platform))
+    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "11.0.5-amzn", platform))
   }
 
   @ChangeSet(order = "205", id = "205-add_adoptopenjdk-hs_8_0_232", author = "andrebrait")
@@ -533,37 +533,37 @@ class JavaMigrations {
     Seq(Linux64, Windows).foreach(removeVersion("java", "11.0.2-open", _))
   }
 
-  @ChangeSet(order = "211", id = "211-add_bellsoft_8_0_232", author = "morgion")
+  @ChangeSet(order = "211", id = "211-add_bellsoft_8_0_242", author = "morgion")
   def migrate211(implicit db: MongoDatabase) = {
     List(
-      Version("java", "8.0.232-librca", "https://download.bell-sw.com/java/8u232+10/bellsoft-jdk8u232+10-linux-i586.tar.gz", Linux32, Some(Liberica)),
-      Version("java", "8.0.232-librca", "https://download.bell-sw.com/java/8u232+10/bellsoft-jdk8u232+10-linux-amd64.tar.gz", Linux64, Some(Liberica)),
-      Version("java", "8.0.232-librca", "https://download.bell-sw.com/java/8u232+10/bellsoft-jdk8u232+10-windows-amd64.zip", Windows, Some(Liberica)),
-      Version("java", "8.0.232-librca", "https://download.bell-sw.com/java/8u232+10/bellsoft-jdk8u232+10-macos-amd64.zip", MacOSX, Some(Liberica))
+      Version("java", "8.0.242-librca", "https://download.bell-sw.com/java/8u242+7/bellsoft-jdk8u242+7-linux-i586.tar.gz", Linux32, Some(Liberica)),
+      Version("java", "8.0.242-librca", "https://download.bell-sw.com/java/8u242+7/bellsoft-jdk8u242+7-linux-amd64.tar.gz", Linux64, Some(Liberica)),
+      Version("java", "8.0.242-librca", "https://download.bell-sw.com/java/8u242+7/bellsoft-jdk8u242+7-windows-amd64.zip", Windows, Some(Liberica)),
+      Version("java", "8.0.242-librca", "https://download.bell-sw.com/java/8u242+7/bellsoft-jdk8u242+7-macos-amd64.zip", MacOSX, Some(Liberica))
     ).validate().insert()
-    Seq(Linux32, Linux64, MacOSX, Windows).foreach(removeVersion("java", "8.0.222-librca", _))
+    Seq(Linux32, Linux64, MacOSX, Windows).foreach(removeVersion("java", "8.0.232-librca", _))
   }
 
-  @ChangeSet(order = "212", id = "212-add_bellsoft_11_0_5", author = "morgion")
+  @ChangeSet(order = "212", id = "212-add_bellsoft_11_0_6", author = "morgion")
   def migrate212(implicit db: MongoDatabase) = {
     List(
-      Version("java", "11.0.5-librca", "https://download.bell-sw.com/java/11.0.5+11/bellsoft-jdk11.0.5+11-linux-i586.tar.gz", Linux32, Some(Liberica)),
-      Version("java", "11.0.5-librca", "https://download.bell-sw.com/java/11.0.5+11/bellsoft-jdk11.0.5+11-linux-amd64.tar.gz", Linux64, Some(Liberica)),
-      Version("java", "11.0.5-librca", "https://download.bell-sw.com/java/11.0.5+11/bellsoft-jdk11.0.5+11-windows-amd64.zip", Windows, Some(Liberica)),
-      Version("java", "11.0.5-librca", "https://download.bell-sw.com/java/11.0.5+11/bellsoft-jdk11.0.5+11-macos-amd64.zip", MacOSX, Some(Liberica))
+      Version("java", "11.0.6-librca", "https://download.bell-sw.com/java/11.0.6+11/bellsoft-jdk11.0.6+10-linux-i586.tar.gz", Linux32, Some(Liberica)),
+      Version("java", "11.0.6-librca", "https://download.bell-sw.com/java/11.0.6+11/bellsoft-jdk11.0.6+10-linux-amd64.tar.gz", Linux64, Some(Liberica)),
+      Version("java", "11.0.6-librca", "https://download.bell-sw.com/java/11.0.6+11/bellsoft-jdk11.0.6+10-windows-amd64.zip", Windows, Some(Liberica)),
+      Version("java", "11.0.6-librca", "https://download.bell-sw.com/java/11.0.6+11/bellsoft-jdk11.0.6+14-macos-amd64.zip", MacOSX, Some(Liberica))
     ).validate().insert()
-    Seq(Linux32, Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.4-librca", _))
+    Seq(Linux32, Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.5-librca", _))
   }
 
-  @ChangeSet(order = "213", id = "213-add_bellsoft_13_0_1", author = "morgion")
+  @ChangeSet(order = "213", id = "213-add_bellsoft_13_0_2", author = "morgion")
   def migrate213(implicit db: MongoDatabase) = {
     List(
-      Version("java", "13.0.1-librca", "https://download.bell-sw.com/java/13.0.1/bellsoft-jdk13.0.1-linux-i586.tar.gz", Linux32, Some(Liberica)),
-      Version("java", "13.0.1-librca", "https://download.bell-sw.com/java/13.0.1/bellsoft-jdk13.0.1-linux-amd64.tar.gz", Linux64, Some(Liberica)),
-      Version("java", "13.0.1-librca", "https://download.bell-sw.com/java/13.0.1/bellsoft-jdk13.0.1-windows-amd64.zip", Windows, Some(Liberica)),
-      Version("java", "13.0.1-librca", "https://download.bell-sw.com/java/13.0.1/bellsoft-jdk13.0.1-macos-amd64.zip", MacOSX, Some(Liberica))
+      Version("java", "13.0.2-librca", "https://download.bell-sw.com/java/13.0.2/bellsoft-jdk13.0.2-linux-i586.tar.gz", Linux32, Some(Liberica)),
+      Version("java", "13.0.2-librca", "https://download.bell-sw.com/java/13.0.2/bellsoft-jdk13.0.2-linux-amd64.tar.gz", Linux64, Some(Liberica)),
+      Version("java", "13.0.2-librca", "https://download.bell-sw.com/java/13.0.2/bellsoft-jdk13.0.2-windows-amd64.zip", Windows, Some(Liberica)),
+      Version("java", "13.0.2-librca", "https://download.bell-sw.com/java/13.0.2/bellsoft-jdk13.0.2-macos-amd64.zip", MacOSX, Some(Liberica))
     ).validate().insert()
-    Seq(Linux32, Linux64, MacOSX, Windows).foreach(removeVersion("java", "13.0.0-librca", _))
+    Seq(Linux32, Linux64, MacOSX, Windows).foreach(removeVersion("java", "13.0.1-librca", _))
   }
 
   @ChangeSet(order = "214", id = "214-fix_openjdk_8_0_232", author = "andrebrait")

--- a/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JavaMigrations.scala
@@ -208,14 +208,14 @@ class JavaMigrations {
     Seq(Linux64, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "19.1.0-grl", platform))
   }
 
-  @ChangeSet(order = "165", id = "165-add_sapmchn_11_0_6", author = "jorsol")
+  @ChangeSet(order = "165", id = "165-add_sapmchn_11_0_4", author = "jorsol")
   def migrate165(implicit db: MongoDatabase) = {
     List(
-      Version("java", "11.0.6-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.6/sapmachine-jdk-11.0.6_linux-x64_bin.tar.gz", Linux64, Some(SAP)),
-      Version("java", "11.0.6-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.6/sapmachine-jdk-11.0.6_windows-x64_bin.zip", Windows, Some(SAP)),
-      Version("java", "11.0.6-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.6/sapmachine-jdk-11.0.6_osx-x64_bin.tar.gz", MacOSX, Some(SAP))
+      Version("java", "11.0.4-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.4/sapmachine-jdk-11.0.4_linux-x64_bin.tar.gz", Linux64, Some(SAP)),
+      Version("java", "11.0.4-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.4/sapmachine-jdk-11.0.4_windows-x64_bin.zip", Windows, Some(SAP)),
+      Version("java", "11.0.4-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.4/sapmachine-jdk-11.0.4_osx-x64_bin.tar.gz", MacOSX, Some(SAP))
     ).validate().insert()
-    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "11.0.4-sapmchn", platform))
+    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "11.0.3-sapmchn", platform))
   }
 
   @ChangeSet(order = "166", id = "166-add_sapmchn_12_0_2", author = "jorsol")
@@ -358,13 +358,13 @@ class JavaMigrations {
       .insert()
   }
 
-  @ChangeSet(order = "195", id = "195-add_openjdk_java_13.0.2", author = "eddumelendez")
+  @ChangeSet(order = "195", id = "195-add_openjdk_java_13.0.1", author = "eddumelendez")
   def migrate195(implicit db: MongoDatabase) = {
-    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "13.0.1-open", _))
+    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "13.0.0-open", _))
     List(
-      Version("java", "13.0.2-open", "https://download.java.net/java/GA/jdk13.0.2/d4173c853231432d94f001e99d882ca7/8/GPL/openjdk-13.0.2_linux-x64_bin.tar.gz", Linux64, Some(OpenJDK)),
-      Version("java", "13.0.2-open", "https://download.java.net/java/GA/jdk13.0.2/d4173c853231432d94f001e99d882ca7/8/GPL/openjdk-13.0.2_osx-x64_bin.tar.gz", MacOSX, Some(OpenJDK)),
-      Version("java", "13.0.2-open", "https://download.java.net/java/GA/jdk13.0.2/d4173c853231432d94f001e99d882ca7/8/GPL/openjdk-13.0.2_windows-x64_bin.zip", Windows, Some(OpenJDK)))
+      Version("java", "13.0.1-open", "https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_linux-x64_bin.tar.gz", Linux64, Some(OpenJDK)),
+      Version("java", "13.0.1-open", "https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_osx-x64_bin.tar.gz", MacOSX, Some(OpenJDK)),
+      Version("java", "13.0.1-open", "https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_windows-x64_bin.zip", Windows, Some(OpenJDK)))
       .validate()
       .insert()
   }
@@ -389,34 +389,34 @@ class JavaMigrations {
     Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "7.0.232-zulu", platform))
   }
 
-  @ChangeSet(order = "198", id = "198-add_zulu_8_0_242", author = "jorsol")
+  @ChangeSet(order = "198", id = "198-add_zulu_8_0_232", author = "jorsol")
   def migrate198(implicit db: MongoDatabase) = {
     List(
-      Version("java", "8.0.242-zulu", "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-linux_x64.tar.gz", Linux64, Some(Zulu)),
-      Version("java", "8.0.242-zulu", "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-win_x64.zip", Windows, Some(Zulu)),
-      Version("java", "8.0.242-zulu", "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-macosx_x64.tar.gz", MacOSX, Some(Zulu))
+      Version("java", "8.0.232-zulu", "https://cdn.azul.com/zulu/bin/zulu8.42.0.21-ca-jdk8.0.232-linux_x64.tar.gz", Linux64, Some(Zulu)),
+      Version("java", "8.0.232-zulu", "https://cdn.azul.com/zulu/bin/zulu8.42.0.21-ca-jdk8.0.232-win_x64.zip", Windows, Some(Zulu)),
+      Version("java", "8.0.232-zulu", "https://cdn.azul.com/zulu/bin/zulu8.42.0.21-ca-jdk8.0.232-macosx_x64.tar.gz", MacOSX, Some(Zulu))
     ).validate().insert()
     Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "8.0.222-zulu", platform))
   }
 
-  @ChangeSet(order = "199", id = "199-add_zulu_11_0_6", author = "jorsol")
+  @ChangeSet(order = "199", id = "199-add_zulu_11_0_5", author = "jorsol")
   def migrate199(implicit db: MongoDatabase) = {
     List(
-      Version("java", "11.0.6-zulu", "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz", Linux64, Some(Zulu)),
-      Version("java", "11.0.6-zulu", "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-win_x64.zip", Windows, Some(Zulu)),
-      Version("java", "11.0.6-zulu", "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz", MacOSX, Some(Zulu))
+      Version("java", "11.0.5-zulu", "https://cdn.azul.com/zulu/bin/zulu11.35.13-ca-jdk11.0.5-linux_x64.tar.gz", Linux64, Some(Zulu)),
+      Version("java", "11.0.5-zulu", "https://cdn.azul.com/zulu/bin/zulu11.35.13-ca-jdk11.0.5-win_x64.zip", Windows, Some(Zulu)),
+      Version("java", "11.0.5-zulu", "https://cdn.azul.com/zulu/bin/zulu11.35.13-ca-jdk11.0.5-macosx_x64.tar.gz", MacOSX, Some(Zulu))
     ).validate().insert()
-    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "11.0.5-zulu", platform))
+    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "11.0.4-zulu", platform))
   }
 
-  @ChangeSet(order = "200", id = "200-add_zulu_13_0_2", author = "jorsol")
+  @ChangeSet(order = "200", id = "200-add_zulu_13_0_1", author = "jorsol")
   def migrate200(implicit db: MongoDatabase) = {
     List(
-      Version("java", "13.0.2-zulu", "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-linux_x64.tar.gz", Linux64, Some(Zulu)),
-      Version("java", "13.0.2-zulu", "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-win_x64.zip", Windows, Some(Zulu)),
-      Version("java", "13.0.2-zulu", "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-macosx_x64.tar.gz", MacOSX, Some(Zulu))
+      Version("java", "13.0.1-zulu", "https://cdn.azul.com/zulu/bin/zulu13.28.11-ca-jdk13.0.1-linux_x64.tar.gz", Linux64, Some(Zulu)),
+      Version("java", "13.0.1-zulu", "https://cdn.azul.com/zulu/bin/zulu13.28.11-ca-jdk13.0.1-win_x64.zip", Windows, Some(Zulu)),
+      Version("java", "13.0.1-zulu", "https://cdn.azul.com/zulu/bin/zulu13.28.11-ca-jdk13.0.1-macosx_x64.tar.gz", MacOSX, Some(Zulu))
     ).validate().insert()
-    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "13.0.1-zulu", platform))
+    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "13.0.0-zulu", platform))
   }
 
   @ChangeSet(order = "201", id = "201-add_graalvm_19_2_1", author = "ilopmar")
@@ -450,24 +450,24 @@ class JavaMigrations {
     Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "19.2.0.1-grl", platform))
   }
 
-  @ChangeSet(order = "203", id = "203-add_corretto_java8_update_242", author = "philiplourandos")
+  @ChangeSet(order = "203", id = "203-add_corretto_java8_update_232", author = "philiplourandos")
   def migrate203(implicit db: MongoDatabase) = {
     List(
-      Version("java", "8.0.242-amzn", "https://corretto.aws/downloads/resources/8.242.07.1/amazon-corretto-8.242.07.1-linux-x64.tar.gz", Linux64, Some(Amazon)),
-      Version("java", "8.0.242-amzn", "https://corretto.aws/downloads/resources/8.242.07.1/amazon-corretto-8.242.07.1-macosx-x64.tar.gz", MacOSX, Some(Amazon)),
-      Version("java", "8.0.242-amzn", "https://corretto.aws/downloads/resources/8.242.07.1/amazon-corretto-8.242.07.1-windows-x64-jdk.zip", Windows, Some(Amazon))
+      Version("java", "8.0.232-amzn", "https://d3pxv6yz143wms.cloudfront.net/8.232.09.1/amazon-corretto-8.232.09.1-linux-x64.tar.gz", Linux64, Some(Amazon)),
+      Version("java", "8.0.232-amzn", "https://d3pxv6yz143wms.cloudfront.net/8.232.09.1/amazon-corretto-8.232.09.1-macosx-x64.tar.gz", MacOSX, Some(Amazon)),
+      Version("java", "8.0.232-amzn", "https://d3pxv6yz143wms.cloudfront.net/8.232.09.1/amazon-corretto-8.232.09.1-windows-x64-jdk.zip", Windows, Some(Amazon))
     ).validate().insert()
-    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "8.0.232-amzn", platform))
+    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "8.0.222-amzn", platform))
   }
 
-  @ChangeSet(order = "204", id = "204-add_corretto_java11_update_6", author = "philiplourandos")
+  @ChangeSet(order = "204", id = "204-add_corretto_java11_update_5", author = "philiplourandos")
   def migrate204(implicit db: MongoDatabase) = {
     List(
-      Version("java", "11.0.6-amzn", "https://corretto.aws/downloads/resources/11.0.6.10.1/amazon-corretto-11.0.6.10.1-linux-x64.tar.gz", Linux64, Some(Amazon)),
-      Version("java", "11.0.6-amzn", "https://corretto.aws/downloads/resources/11.0.6.10.1/amazon-corretto-11.0.6.10.1-macosx-x64.tar.gz", MacOSX, Some(Amazon)),
-      Version("java", "11.0.6-amzn", "https://corretto.aws/downloads/resources/11.0.6.10.1/amazon-corretto-11.0.6.10.1-windows-x64-jdk.zip", Windows, Some(Amazon))
+      Version("java", "11.0.5-amzn", "https://d3pxv6yz143wms.cloudfront.net/11.0.5.10.1/amazon-corretto-11.0.5.10.1-linux-x64.tar.gz", Linux64, Some(Amazon)),
+      Version("java", "11.0.5-amzn", "https://d3pxv6yz143wms.cloudfront.net/11.0.5.10.1/amazon-corretto-11.0.5.10.1-macosx-x64.tar.gz", MacOSX, Some(Amazon)),
+      Version("java", "11.0.5-amzn", "https://d3pxv6yz143wms.cloudfront.net/11.0.5.10.1/amazon-corretto-11.0.5.10.1-windows-x64.zip", Windows, Some(Amazon))
     ).validate().insert()
-    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "11.0.5-amzn", platform))
+    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "11.0.4-amzn", platform))
   }
 
   @ChangeSet(order = "205", id = "205-add_adoptopenjdk-hs_8_0_232", author = "andrebrait")
@@ -533,37 +533,37 @@ class JavaMigrations {
     Seq(Linux64, Windows).foreach(removeVersion("java", "11.0.2-open", _))
   }
 
-  @ChangeSet(order = "211", id = "211-add_bellsoft_8_0_242", author = "morgion")
+  @ChangeSet(order = "211", id = "211-add_bellsoft_8_0_232", author = "morgion")
   def migrate211(implicit db: MongoDatabase) = {
     List(
-      Version("java", "8.0.242-librca", "https://download.bell-sw.com/java/8u242+7/bellsoft-jdk8u242+7-linux-i586.tar.gz", Linux32, Some(Liberica)),
-      Version("java", "8.0.242-librca", "https://download.bell-sw.com/java/8u242+7/bellsoft-jdk8u242+7-linux-amd64.tar.gz", Linux64, Some(Liberica)),
-      Version("java", "8.0.242-librca", "https://download.bell-sw.com/java/8u242+7/bellsoft-jdk8u242+7-windows-amd64.zip", Windows, Some(Liberica)),
-      Version("java", "8.0.242-librca", "https://download.bell-sw.com/java/8u242+7/bellsoft-jdk8u242+7-macos-amd64.zip", MacOSX, Some(Liberica))
+      Version("java", "8.0.232-librca", "https://download.bell-sw.com/java/8u232+10/bellsoft-jdk8u232+10-linux-i586.tar.gz", Linux32, Some(Liberica)),
+      Version("java", "8.0.232-librca", "https://download.bell-sw.com/java/8u232+10/bellsoft-jdk8u232+10-linux-amd64.tar.gz", Linux64, Some(Liberica)),
+      Version("java", "8.0.232-librca", "https://download.bell-sw.com/java/8u232+10/bellsoft-jdk8u232+10-windows-amd64.zip", Windows, Some(Liberica)),
+      Version("java", "8.0.232-librca", "https://download.bell-sw.com/java/8u232+10/bellsoft-jdk8u232+10-macos-amd64.zip", MacOSX, Some(Liberica))
     ).validate().insert()
-    Seq(Linux32, Linux64, MacOSX, Windows).foreach(removeVersion("java", "8.0.232-librca", _))
+    Seq(Linux32, Linux64, MacOSX, Windows).foreach(removeVersion("java", "8.0.222-librca", _))
   }
 
-  @ChangeSet(order = "212", id = "212-add_bellsoft_11_0_6", author = "morgion")
+  @ChangeSet(order = "212", id = "212-add_bellsoft_11_0_5", author = "morgion")
   def migrate212(implicit db: MongoDatabase) = {
     List(
-      Version("java", "11.0.6-librca", "https://download.bell-sw.com/java/11.0.6+11/bellsoft-jdk11.0.6+10-linux-i586.tar.gz", Linux32, Some(Liberica)),
-      Version("java", "11.0.6-librca", "https://download.bell-sw.com/java/11.0.6+11/bellsoft-jdk11.0.6+10-linux-amd64.tar.gz", Linux64, Some(Liberica)),
-      Version("java", "11.0.6-librca", "https://download.bell-sw.com/java/11.0.6+11/bellsoft-jdk11.0.6+10-windows-amd64.zip", Windows, Some(Liberica)),
-      Version("java", "11.0.6-librca", "https://download.bell-sw.com/java/11.0.6+11/bellsoft-jdk11.0.6+14-macos-amd64.zip", MacOSX, Some(Liberica))
+      Version("java", "11.0.5-librca", "https://download.bell-sw.com/java/11.0.5+11/bellsoft-jdk11.0.5+11-linux-i586.tar.gz", Linux32, Some(Liberica)),
+      Version("java", "11.0.5-librca", "https://download.bell-sw.com/java/11.0.5+11/bellsoft-jdk11.0.5+11-linux-amd64.tar.gz", Linux64, Some(Liberica)),
+      Version("java", "11.0.5-librca", "https://download.bell-sw.com/java/11.0.5+11/bellsoft-jdk11.0.5+11-windows-amd64.zip", Windows, Some(Liberica)),
+      Version("java", "11.0.5-librca", "https://download.bell-sw.com/java/11.0.5+11/bellsoft-jdk11.0.5+11-macos-amd64.zip", MacOSX, Some(Liberica))
     ).validate().insert()
-    Seq(Linux32, Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.5-librca", _))
+    Seq(Linux32, Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.4-librca", _))
   }
 
-  @ChangeSet(order = "213", id = "213-add_bellsoft_13_0_2", author = "morgion")
+  @ChangeSet(order = "213", id = "213-add_bellsoft_13_0_1", author = "morgion")
   def migrate213(implicit db: MongoDatabase) = {
     List(
-      Version("java", "13.0.2-librca", "https://download.bell-sw.com/java/13.0.2/bellsoft-jdk13.0.2-linux-i586.tar.gz", Linux32, Some(Liberica)),
-      Version("java", "13.0.2-librca", "https://download.bell-sw.com/java/13.0.2/bellsoft-jdk13.0.2-linux-amd64.tar.gz", Linux64, Some(Liberica)),
-      Version("java", "13.0.2-librca", "https://download.bell-sw.com/java/13.0.2/bellsoft-jdk13.0.2-windows-amd64.zip", Windows, Some(Liberica)),
-      Version("java", "13.0.2-librca", "https://download.bell-sw.com/java/13.0.2/bellsoft-jdk13.0.2-macos-amd64.zip", MacOSX, Some(Liberica))
+      Version("java", "13.0.1-librca", "https://download.bell-sw.com/java/13.0.1/bellsoft-jdk13.0.1-linux-i586.tar.gz", Linux32, Some(Liberica)),
+      Version("java", "13.0.1-librca", "https://download.bell-sw.com/java/13.0.1/bellsoft-jdk13.0.1-linux-amd64.tar.gz", Linux64, Some(Liberica)),
+      Version("java", "13.0.1-librca", "https://download.bell-sw.com/java/13.0.1/bellsoft-jdk13.0.1-windows-amd64.zip", Windows, Some(Liberica)),
+      Version("java", "13.0.1-librca", "https://download.bell-sw.com/java/13.0.1/bellsoft-jdk13.0.1-macos-amd64.zip", MacOSX, Some(Liberica))
     ).validate().insert()
-    Seq(Linux32, Linux64, MacOSX, Windows).foreach(removeVersion("java", "13.0.1-librca", _))
+    Seq(Linux32, Linux64, MacOSX, Windows).foreach(removeVersion("java", "13.0.0-librca", _))
   }
 
   @ChangeSet(order = "214", id = "214-fix_openjdk_8_0_232", author = "andrebrait")

--- a/src/main/scala/io/sdkman/changelogs/java/AdoptOpenJdkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/AdoptOpenJdkMigrations.scala
@@ -23,4 +23,16 @@ class AdoptOpenJdkMigrations {
       removeVersion("java", "13.0.0.hs-adpt", platform)
     }
   }
+
+  @ChangeSet(order = "0002", id = "0002-add_adoptopenjdk-hs_11_0_6", author = "poad")
+  def migrate0002(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "11.0.6.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6+10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.6_10.tar.gz", Linux64, Some(AdoptOpenJDK)),
+      Version("java", "11.0.6.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6+10/OpenJDK11U-jdk_x64_mac_hotspot_11.0.6_10.tar.gz", MacOSX, Some(AdoptOpenJDK)),
+      Version("java", "11.0.6.hs-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6+10/OpenJDK11U-jdk_x64_windows_hotspot_11.0.6_10.zip", Windows, Some(AdoptOpenJDK)))
+      .validate()
+      .insert()
+    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.5.hs-adpt", _))
+  }
+
 }

--- a/src/main/scala/io/sdkman/changelogs/java/AdoptOpenJdkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/AdoptOpenJdkMigrations.scala
@@ -35,4 +35,15 @@ class AdoptOpenJdkMigrations {
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.5.hs-adpt", _))
   }
 
+
+  @ChangeSet(order = "0003", id = "0009-add_adoptopenjdk-j9_11_0_6", author = "poad")
+  def migrate0003(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "11.0.6.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10_openj9-0.18.0/OpenJDK11U-jdk_x64_linux_openj9_11.0.6_10_openj9-0.18.0.tar.gz", Linux64, Some(AdoptOpenJDK)),
+      Version("java", "11.0.6.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10_openj9-0.18.0/OpenJDK11U-jdk_x64_mac_openj9_11.0.6_10_openj9-0.18.0.tar.gz", MacOSX, Some(AdoptOpenJDK)),
+      Version("java", "11.0.6.j9-adpt", "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10_openj9-0.18.0/OpenJDK11U-jdk_x64_windows_openj9_11.0.6_10_openj9-0.18.0.zip", Windows, Some(AdoptOpenJDK)))
+      .validate()
+      .insert()
+    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.5.j9-adpt", _))
+  }
 }

--- a/src/main/scala/io/sdkman/changelogs/java/AmazonCorrettoMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/AmazonCorrettoMigrations.scala
@@ -5,5 +5,25 @@ import com.mongodb.client.MongoDatabase
 
 @ChangeLog(order = "017")
 class AmazonCorrettoMigrations {
+  @ChangeSet(order = "0001", id = "0001-add_corretto_java8_update_242", author = "poad")
+  def migrate0001(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "8.0.242-amzn", "https://corretto.aws/downloads/resources/8.242.07.1/amazon-corretto-8.242.07.1-linux-x64.tar.gz", Linux64, Some(Amazon)),
+      Version("java", "8.0.242-amzn", "https://corretto.aws/downloads/resources/8.242.07.1/amazon-corretto-8.242.07.1-macosx-x64.tar.gz", MacOSX, Some(Amazon)),
+      Version("java", "8.0.242-amzn", "https://corretto.aws/downloads/resources/8.242.07.1/amazon-corretto-8.242.07.1-windows-x64-jdk.zip", Windows, Some(Amazon))
+    ).validate().insert()
+    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "8.0.232-amzn", platform))
+  }
+
+  @ChangeSet(order = "0002", id = "0002-add_corretto_java11_update_6", author = "poad")
+  def migrate0002(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "11.0.6-amzn", "https://corretto.aws/downloads/resources/11.0.6.10.1/amazon-corretto-11.0.6.10.1-linux-x64.tar.gz", Linux64, Some(Amazon)),
+      Version("java", "11.0.6-amzn", "https://corretto.aws/downloads/resources/11.0.6.10.1/amazon-corretto-11.0.6.10.1-macosx-x64.tar.gz", MacOSX, Some(Amazon)),
+      Version("java", "11.0.6-amzn", "https://corretto.aws/downloads/resources/11.0.6.10.1/amazon-corretto-11.0.6.10.1-windows-x64-jdk.zip", Windows, Some(Amazon))
+    ).validate().insert()
+    Seq(Linux64, MacOSX, Windows).foreach(platform => removeVersion(candidate = "java", version = "11.0.5-amzn", platform))
+  }
+
 
 }

--- a/src/main/scala/io/sdkman/changelogs/java/AmazonCorrettoMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/AmazonCorrettoMigrations.scala
@@ -2,6 +2,7 @@ package io.sdkman.changelogs.java
 
 import com.github.mongobee.changeset.{ChangeLog, ChangeSet}
 import com.mongodb.client.MongoDatabase
+import io.sdkman.changelogs.{Amazon, Linux64, MacOSX, Version, Windows, _}
 
 @ChangeLog(order = "017")
 class AmazonCorrettoMigrations {

--- a/src/main/scala/io/sdkman/changelogs/java/AzulZuluMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/AzulZuluMigrations.scala
@@ -7,23 +7,23 @@ import io.sdkman.changelogs.{Linux64, MacOSX, Version, Windows, Zulu, removeVers
 @ChangeLog(order = "019")
 class AzulZuluMigrations {
 
-  @ChangeSet(order = "001", id = "001-add_zulu_8_0_232", author = "dimitryc")
+  @ChangeSet(order = "001", id = "001-add_zulu_8_0_242", author = "dimitryc")
   def migrate001(implicit db: MongoDatabase) = {
-    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "8.0.232-zulu", platform))
+    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "8.0.242-zulu", platform))
     List(
-      Version("java", "8.0.232-zulu", "https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz", Linux64, Some(Zulu)),
-      Version("java", "8.0.232-zulu", "https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-win_x64.zip", Windows, Some(Zulu)),
-      Version("java", "8.0.232-zulu", "https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-macosx_x64.tar.gz", MacOSX, Some(Zulu))
+      Version("java", "8.0.242-zulu", "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-linux_x64.tar.gz", Linux64, Some(Zulu)),
+      Version("java", "8.0.242-zulu", "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-win_x64.zip", Windows, Some(Zulu)),
+      Version("java", "8.0.242-zulu", "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-macosx_x64.tar.gz", MacOSX, Some(Zulu))
     ).validate().insert()
   }
 
-  @ChangeSet(order = "002", id = "002-add_zulu_11_0_5", author = "dimitryc")
+  @ChangeSet(order = "002", id = "002-add_zulu_11_0_6", author = "dimitryc")
   def migrate002(implicit db: MongoDatabase) = {
-    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "11.0.5-zulu", platform))
+    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "11.0.6-zulu", platform))
     List(
-      Version("java", "11.0.5-zulu", "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-jdk11.0.5-linux_x64.tar.gz", Linux64, Some(Zulu)),
-      Version("java", "11.0.5-zulu", "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-jdk11.0.5-win_x64.zip", Windows, Some(Zulu)),
-      Version("java", "11.0.5-zulu", "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-jdk11.0.5-macosx_x64.tar.gz", MacOSX, Some(Zulu))
+      Version("java", "11.0.6-zulu", "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz", Linux64, Some(Zulu)),
+      Version("java", "11.0.6-zulu", "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-win_x64.zip", Windows, Some(Zulu)),
+      Version("java", "11.0.6-zulu", "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz", MacOSX, Some(Zulu))
     ).validate().insert()
   }
 }

--- a/src/main/scala/io/sdkman/changelogs/java/AzulZuluMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/AzulZuluMigrations.scala
@@ -46,7 +46,7 @@ class AzulZuluMigrations {
     List(
       Version("java", "11.0.6-zulu", "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz", Linux64, Some(Zulu)),
       Version("java", "11.0.6-zulu", "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-win_x64.zip", Windows, Some(Zulu)),
-      VVersion("java", "11.0.6-zulu", "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz", MacOSX, Some(Zulu))
+      Version("java", "11.0.6-zulu", "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz", MacOSX, Some(Zulu))
     ).validate().insert()
     Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "11.0.5-zulu", platform))
   }

--- a/src/main/scala/io/sdkman/changelogs/java/AzulZuluMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/AzulZuluMigrations.scala
@@ -7,23 +7,23 @@ import io.sdkman.changelogs.{Linux64, MacOSX, Version, Windows, Zulu, removeVers
 @ChangeLog(order = "019")
 class AzulZuluMigrations {
 
-  @ChangeSet(order = "001", id = "001-add_zulu_8_0_242", author = "dimitryc")
+  @ChangeSet(order = "001", id = "001-add_zulu_8_0_232", author = "dimitryc")
   def migrate001(implicit db: MongoDatabase) = {
-    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "8.0.242-zulu", platform))
+    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "8.0.232-zulu", platform))
     List(
-      Version("java", "8.0.242-zulu", "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-linux_x64.tar.gz", Linux64, Some(Zulu)),
-      Version("java", "8.0.242-zulu", "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-win_x64.zip", Windows, Some(Zulu)),
-      Version("java", "8.0.242-zulu", "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-macosx_x64.tar.gz", MacOSX, Some(Zulu))
+      Version("java", "8.0.232-zulu", "https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz", Linux64, Some(Zulu)),
+      Version("java", "8.0.232-zulu", "https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-win_x64.zip", Windows, Some(Zulu)),
+      Version("java", "8.0.232-zulu", "https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-macosx_x64.tar.gz", MacOSX, Some(Zulu))
     ).validate().insert()
   }
 
-  @ChangeSet(order = "002", id = "002-add_zulu_11_0_6", author = "dimitryc")
+  @ChangeSet(order = "002", id = "002-add_zulu_11_0_5", author = "dimitryc")
   def migrate002(implicit db: MongoDatabase) = {
-    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "11.0.6-zulu", platform))
+    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "11.0.5-zulu", platform))
     List(
-      Version("java", "11.0.6-zulu", "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz", Linux64, Some(Zulu)),
-      Version("java", "11.0.6-zulu", "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-win_x64.zip", Windows, Some(Zulu)),
-      Version("java", "11.0.6-zulu", "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz", MacOSX, Some(Zulu))
+      Version("java", "11.0.5-zulu", "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-jdk11.0.5-linux_x64.tar.gz", Linux64, Some(Zulu)),
+      Version("java", "11.0.5-zulu", "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-jdk11.0.5-win_x64.zip", Windows, Some(Zulu)),
+      Version("java", "11.0.5-zulu", "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-jdk11.0.5-macosx_x64.tar.gz", MacOSX, Some(Zulu))
     ).validate().insert()
   }
 }

--- a/src/main/scala/io/sdkman/changelogs/java/AzulZuluMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/AzulZuluMigrations.scala
@@ -15,6 +15,7 @@ class AzulZuluMigrations {
       Version("java", "8.0.232-zulu", "https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-win_x64.zip", Windows, Some(Zulu)),
       Version("java", "8.0.232-zulu", "https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-macosx_x64.tar.gz", MacOSX, Some(Zulu))
     ).validate().insert()
+    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "8.0.222-zulu", platform))
   }
 
   @ChangeSet(order = "002", id = "002-add_zulu_11_0_5", author = "dimitryc")
@@ -25,5 +26,39 @@ class AzulZuluMigrations {
       Version("java", "11.0.5-zulu", "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-jdk11.0.5-win_x64.zip", Windows, Some(Zulu)),
       Version("java", "11.0.5-zulu", "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-jdk11.0.5-macosx_x64.tar.gz", MacOSX, Some(Zulu))
     ).validate().insert()
+    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "11.0.5-zulu", platform))
   }
+
+  @ChangeSet(order = "003", id = "003-add_zulu_8_0_232", author = "poad")
+  def migrate003(implicit db: MongoDatabase) = {
+    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "8.0.232-zulu", platform))
+    List(
+      Version("java", "8.0.242-zulu", "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-linux_x64.tar.gz", Linux64, Some(Zulu)),
+      Version("java", "8.0.242-zulu", "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-win_x64.zip", Windows, Some(Zulu)),
+      Version("java", "8.0.242-zulu", "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-macosx_x64.tar.gz", MacOSX, Some(Zulu))
+    ).validate().insert()
+    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "8.0.232-zulu", platform))
+  }
+
+  @ChangeSet(order = "004", id = "004-add_zulu_11_0_6", author = "poad")
+  def migrate004(implicit db: MongoDatabase) = {
+    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "11.0.5-zulu", platform))
+    List(
+      Version("java", "11.0.6-zulu", "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz", Linux64, Some(Zulu)),
+      Version("java", "11.0.6-zulu", "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-win_x64.zip", Windows, Some(Zulu)),
+      VVersion("java", "11.0.6-zulu", "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz", MacOSX, Some(Zulu))
+    ).validate().insert()
+    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "11.0.5-zulu", platform))
+  }
+
+  @ChangeSet(order = "005", id = "005-add_zulu_13_0_2", author = "poad")
+  def migrate005(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "13.0.2-zulu", "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-linux_x64.tar.gz", Linux64, Some(Zulu)),
+      Version("java", "13.0.2-zulu", "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-win_x64.zip", Windows, Some(Zulu)),
+      Version("java", "13.0.2-zulu", "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-macosx_x64.tar.gz", MacOSX, Some(Zulu))
+    ).validate().insert()
+    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "13.0.1-zulu", platform))
+  }
+
 }

--- a/src/main/scala/io/sdkman/changelogs/java/BellSoftLibericaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/BellSoftLibericaMigrations.scala
@@ -2,6 +2,7 @@ package io.sdkman.changelogs.java
 
 import com.github.mongobee.changeset.{ChangeLog, ChangeSet}
 import com.mongodb.client.MongoDatabase
+import io.sdkman.changelogs.{Linux64, MacOSX, Version, Windows, _}
 
 @ChangeLog(order = "020")
 class BellSoftLibericaMigrations {

--- a/src/main/scala/io/sdkman/changelogs/java/BellSoftLibericaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/BellSoftLibericaMigrations.scala
@@ -5,5 +5,38 @@ import com.mongodb.client.MongoDatabase
 
 @ChangeLog(order = "020")
 class BellSoftLibericaMigrations {
+  @ChangeSet(order = "0001", id = "0001-add_bellsoft_8_0_242", author = "poad")
+  def migrate0001(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "8.0.242-librca", "https://download.bell-sw.com/java/8u242+7/bellsoft-jdk8u242+7-linux-i586.tar.gz", Linux32, Some(Liberica)),
+      Version("java", "8.0.242-librca", "https://download.bell-sw.com/java/8u242+7/bellsoft-jdk8u242+7-linux-amd64.tar.gz", Linux64, Some(Liberica)),
+      Version("java", "8.0.242-librca", "https://download.bell-sw.com/java/8u242+7/bellsoft-jdk8u242+7-windows-amd64.zip", Windows, Some(Liberica)),
+      Version("java", "8.0.242-librca", "https://download.bell-sw.com/java/8u242+7/bellsoft-jdk8u242+7-macos-amd64.zip", MacOSX, Some(Liberica))
+    ).validate().insert()
+    Seq(Linux32, Linux64, MacOSX, Windows).foreach(removeVersion("java", "8.0.232-librca", _))
+  }
+
+  @ChangeSet(order = "0002", id = "0002-add_bellsoft_11_0_6", author = "poad")
+  def migrate0002(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "11.0.6-librca", "https://download.bell-sw.com/java/11.0.6+11/bellsoft-jdk11.0.6+10-linux-i586.tar.gz", Linux32, Some(Liberica)),
+      Version("java", "11.0.6-librca", "https://download.bell-sw.com/java/11.0.6+11/bellsoft-jdk11.0.6+10-linux-amd64.tar.gz", Linux64, Some(Liberica)),
+      Version("java", "11.0.6-librca", "https://download.bell-sw.com/java/11.0.6+11/bellsoft-jdk11.0.6+10-windows-amd64.zip", Windows, Some(Liberica)),
+      Version("java", "11.0.6-librca", "https://download.bell-sw.com/java/11.0.6+11/bellsoft-jdk11.0.6+14-macos-amd64.zip", MacOSX, Some(Liberica))
+    ).validate().insert()
+    Seq(Linux32, Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.5-librca", _))
+  }
+
+  @ChangeSet(order = "0003", id = "0003-add_bellsoft_13_0_2", author = "poad")
+  def migrate0003(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "13.0.2-librca", "https://download.bell-sw.com/java/13.0.2/bellsoft-jdk13.0.2-linux-i586.tar.gz", Linux32, Some(Liberica)),
+      Version("java", "13.0.2-librca", "https://download.bell-sw.com/java/13.0.2/bellsoft-jdk13.0.2-linux-amd64.tar.gz", Linux64, Some(Liberica)),
+      Version("java", "13.0.2-librca", "https://download.bell-sw.com/java/13.0.2/bellsoft-jdk13.0.2-windows-amd64.zip", Windows, Some(Liberica)),
+      Version("java", "13.0.2-librca", "https://download.bell-sw.com/java/13.0.2/bellsoft-jdk13.0.2-macos-amd64.zip", MacOSX, Some(Liberica))
+    ).validate().insert()
+    Seq(Linux32, Linux64, MacOSX, Windows).foreach(removeVersion("java", "13.0.1-librca", _))
+  }
+
 
 }

--- a/src/main/scala/io/sdkman/changelogs/java/BellSoftLibericaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/BellSoftLibericaMigrations.scala
@@ -20,10 +20,10 @@ class BellSoftLibericaMigrations {
   @ChangeSet(order = "0002", id = "0002-add_bellsoft_11_0_6", author = "poad")
   def migrate0002(implicit db: MongoDatabase) = {
     List(
-      Version("java", "11.0.6-librca", "https://download.bell-sw.com/java/11.0.6+11/bellsoft-jdk11.0.6+10-linux-i586.tar.gz", Linux32, Some(Liberica)),
-      Version("java", "11.0.6-librca", "https://download.bell-sw.com/java/11.0.6+11/bellsoft-jdk11.0.6+10-linux-amd64.tar.gz", Linux64, Some(Liberica)),
-      Version("java", "11.0.6-librca", "https://download.bell-sw.com/java/11.0.6+11/bellsoft-jdk11.0.6+10-windows-amd64.zip", Windows, Some(Liberica)),
-      Version("java", "11.0.6-librca", "https://download.bell-sw.com/java/11.0.6+11/bellsoft-jdk11.0.6+14-macos-amd64.zip", MacOSX, Some(Liberica))
+      Version("java", "11.0.6-librca", "https://download.bell-sw.com/java/11.0.6+10/bellsoft-jdk11.0.6+10-linux-i586.tar.gz", Linux32, Some(Liberica)),
+      Version("java", "11.0.6-librca", "https://download.bell-sw.com/java/11.0.6+10/bellsoft-jdk11.0.6+10-linux-amd64.tar.gz", Linux64, Some(Liberica)),
+      Version("java", "11.0.6-librca", "https://download.bell-sw.com/java/11.0.6+10/bellsoft-jdk11.0.6+10-windows-amd64.zip", Windows, Some(Liberica)),
+      Version("java", "11.0.6-librca", "https://download.bell-sw.com/java/11.0.6+10/bellsoft-jdk11.0.6+10-macos-amd64.zip", MacOSX, Some(Liberica))
     ).validate().insert()
     Seq(Linux32, Linux64, MacOSX, Windows).foreach(removeVersion("java", "11.0.5-librca", _))
   }
@@ -31,10 +31,10 @@ class BellSoftLibericaMigrations {
   @ChangeSet(order = "0003", id = "0003-add_bellsoft_13_0_2", author = "poad")
   def migrate0003(implicit db: MongoDatabase) = {
     List(
-      Version("java", "13.0.2-librca", "https://download.bell-sw.com/java/13.0.2/bellsoft-jdk13.0.2-linux-i586.tar.gz", Linux32, Some(Liberica)),
-      Version("java", "13.0.2-librca", "https://download.bell-sw.com/java/13.0.2/bellsoft-jdk13.0.2-linux-amd64.tar.gz", Linux64, Some(Liberica)),
-      Version("java", "13.0.2-librca", "https://download.bell-sw.com/java/13.0.2/bellsoft-jdk13.0.2-windows-amd64.zip", Windows, Some(Liberica)),
-      Version("java", "13.0.2-librca", "https://download.bell-sw.com/java/13.0.2/bellsoft-jdk13.0.2-macos-amd64.zip", MacOSX, Some(Liberica))
+      Version("java", "13.0.2-librca", "https://download.bell-sw.com/java/13.0.2+9/bellsoft-jdk13.0.2+9-linux-i586.tar.gz", Linux32, Some(Liberica)),
+      Version("java", "13.0.2-librca", "https://download.bell-sw.com/java/13.0.2+9/bellsoft-jdk13.0.2+9-linux-amd64.tar.gz", Linux64, Some(Liberica)),
+      Version("java", "13.0.2-librca", "https://download.bell-sw.com/java/13.0.2+9/bellsoft-jdk13.0.2+9-windows-amd64.zip", Windows, Some(Liberica)),
+      Version("java", "13.0.2-librca", "https://download.bell-sw.com/java/13.0.2+9/bellsoft-jdk13.0.2+9-macos-amd64.zip", MacOSX, Some(Liberica))
     ).validate().insert()
     Seq(Linux32, Linux64, MacOSX, Windows).foreach(removeVersion("java", "13.0.1-librca", _))
   }

--- a/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
@@ -7,16 +7,16 @@ import io.sdkman.changelogs.{Linux64, MacOSX, OpenJDK, Version, Windows, removeV
 @ChangeLog(order = "022")
 class OpenJdkMigrations {
 
-  @ChangeSet(order = "001", id = "001-add_openjdk_java_14-ea-20", author = "eddumelendez")
-  def migrate001(implicit db: MongoDatabase): Unit = {
-    List(
-      Version("java", "14.ea.20-open", "https://download.java.net/java/early_access/jdk14/20/GPL/openjdk-14-ea+20_linux-x64_bin.tar.gz", Linux64, Some(OpenJDK)),
-      Version("java", "14.ea.20-open", "https://download.java.net/java/early_access/jdk14/20/GPL/openjdk-14-ea+20_osx-x64_bin.tar.gz", MacOSX, Some(OpenJDK)),
-      Version("java", "14.ea.20-open", "https://download.java.net/java/early_access/jdk14/20/GPL/openjdk-14-ea+20_windows-x64_bin.zip", Windows, Some(OpenJDK)))
-      .validate()
-      .insert()
-    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "14.ea.18-open", _))
-  }
+//  @ChangeSet(order = "001", id = "001-add_openjdk_java_14-ea-20", author = "eddumelendez")
+//  def migrate001(implicit db: MongoDatabase): Unit = {
+//    List(
+//      Version("java", "14.ea.20-open", "https://download.java.net/java/early_access/jdk14/20/GPL/openjdk-14-ea+20_linux-x64_bin.tar.gz", Linux64, Some(OpenJDK)),
+//      Version("java", "14.ea.20-open", "https://download.java.net/java/early_access/jdk14/20/GPL/openjdk-14-ea+20_osx-x64_bin.tar.gz", MacOSX, Some(OpenJDK)),
+//      Version("java", "14.ea.20-open", "https://download.java.net/java/early_access/jdk14/20/GPL/openjdk-14-ea+20_windows-x64_bin.zip", Windows, Some(OpenJDK)))
+//      .validate()
+//      .insert()
+//    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "14.ea.18-open", _))
+//  }
 
   @ChangeSet(order = "002", id = "002-add_openjdk_java_14-ea-22", author = "eddumelendez")
   def migrate002(implicit db: MongoDatabase): Unit = {

--- a/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
@@ -7,17 +7,6 @@ import io.sdkman.changelogs.{Linux64, MacOSX, OpenJDK, Version, Windows, removeV
 @ChangeLog(order = "022")
 class OpenJdkMigrations {
 
-//  @ChangeSet(order = "001", id = "001-add_openjdk_java_14-ea-20", author = "eddumelendez")
-//  def migrate001(implicit db: MongoDatabase): Unit = {
-//    List(
-//      Version("java", "14.ea.20-open", "https://download.java.net/java/early_access/jdk14/20/GPL/openjdk-14-ea+20_linux-x64_bin.tar.gz", Linux64, Some(OpenJDK)),
-//      Version("java", "14.ea.20-open", "https://download.java.net/java/early_access/jdk14/20/GPL/openjdk-14-ea+20_osx-x64_bin.tar.gz", MacOSX, Some(OpenJDK)),
-//      Version("java", "14.ea.20-open", "https://download.java.net/java/early_access/jdk14/20/GPL/openjdk-14-ea+20_windows-x64_bin.zip", Windows, Some(OpenJDK)))
-//      .validate()
-//      .insert()
-//    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "14.ea.18-open", _))
-//  }
-
   @ChangeSet(order = "002", id = "002-add_openjdk_java_14-ea-22", author = "eddumelendez")
   def migrate002(implicit db: MongoDatabase): Unit = {
     List(

--- a/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
@@ -136,4 +136,14 @@ class OpenJdkMigrations {
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "15.ea.2-open", _))
   }
 
+  @ChangeSet(order = "014", id = "014-add_openjdk_java_13.0.2", author = "poad")
+  def migrate014(implicit db: MongoDatabase) = {
+    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "13.0.1-open", _))
+    List(
+      Version("java", "13.0.2-open", "https://download.java.net/java/GA/jdk13.0.2/d4173c853231432d94f001e99d882ca7/8/GPL/openjdk-13.0.2_linux-x64_bin.tar.gz", Linux64, Some(OpenJDK)),
+      Version("java", "13.0.2-open", "https://download.java.net/java/GA/jdk13.0.2/d4173c853231432d94f001e99d882ca7/8/GPL/openjdk-13.0.2_osx-x64_bin.tar.gz", MacOSX, Some(OpenJDK)),
+      Version("java", "13.0.2-open", "https://download.java.net/java/GA/jdk13.0.2/d4173c853231432d94f001e99d882ca7/8/GPL/openjdk-13.0.2_windows-x64_bin.zip", Windows, Some(OpenJDK)))
+      .validate()
+      .insert()
+  }
 }

--- a/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
@@ -147,8 +147,8 @@ class OpenJdkMigrations {
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "15.ea.4-open", _))
   }
 
-  @ChangeSet(order = "015", id = "015-add_openjdk_java_13.0.2", author = "poad")
-  def migrate015(implicit db: MongoDatabase) = {
+  @ChangeSet(order = "016", id = "016-add_openjdk_java_13.0.2", author = "poad")
+  def migrate016(implicit db: MongoDatabase) = {
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "13.0.1-open", _))
     List(
       Version("java", "13.0.2-open", "https://download.java.net/java/GA/jdk13.0.2/d4173c853231432d94f001e99d882ca7/8/GPL/openjdk-13.0.2_linux-x64_bin.tar.gz", Linux64, Some(OpenJDK)),
@@ -158,13 +158,13 @@ class OpenJdkMigrations {
       .insert()
   }
 
-  @ChangeSet(order = "016", id = "016-remove_openjdk_java_14.ea.18-open", author = "poad")
-  def migrate016(implicit db: MongoDatabase): Unit = {
+  @ChangeSet(order = "017", id = "017-remove_openjdk_java_14.ea.18-open", author = "poad")
+  def migrate017(implicit db: MongoDatabase): Unit = {
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "14.ea.18-open", _))
   }
 
-  @ChangeSet(order = "017", id = "017-remove_openjdk_14.ea.20-open", author = "poad")
-  def migrate017(implicit db: MongoDatabase): Unit = {
+  @ChangeSet(order = "018", id = "018-remove_openjdk_14.ea.20-open", author = "poad")
+  def migrate018(implicit db: MongoDatabase): Unit = {
     Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "14.ea.20-open", _))
   }
 }

--- a/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
@@ -146,4 +146,14 @@ class OpenJdkMigrations {
       .validate()
       .insert()
   }
+
+  @ChangeSet(order = "015", id = "015-remove_openjdk_java_14.ea.18-open", author = "poad")
+  def migrate015(implicit db: MongoDatabase): Unit = {
+    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "14.ea.18-open", _))
+  }
+
+  @ChangeSet(order = "016", id = "016-remove_openjdk_14.ea.20-open", author = "poad")
+  def migrate016(implicit db: MongoDatabase): Unit = {
+    Seq(Linux64, MacOSX, Windows).foreach(removeVersion("java", "14.ea.20-open", _))
+  }
 }

--- a/src/main/scala/io/sdkman/changelogs/java/SapMachineMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/SapMachineMigrations.scala
@@ -2,6 +2,7 @@ package io.sdkman.changelogs.java
 
 import com.github.mongobee.changeset.{ChangeLog, ChangeSet}
 import com.mongodb.client.MongoDatabase
+import io.sdkman.changelogs.{Linux64, MacOSX, Version, Windows, _}
 
 @ChangeLog(order = "023")
 class SapMachineMigrations {

--- a/src/main/scala/io/sdkman/changelogs/java/SapMachineMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/SapMachineMigrations.scala
@@ -5,5 +5,22 @@ import com.mongodb.client.MongoDatabase
 
 @ChangeLog(order = "023")
 class SapMachineMigrations {
+  @ChangeSet(order = "0001", id = "0001-add_sapmchn_11_0_6", author = "poad")
+  def migrate0001(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "11.0.6-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.6/sapmachine-jdk-11.0.6_linux-x64_bin.tar.gz", Linux64, Some(SAP)),
+      Version("java", "11.0.6-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.6/sapmachine-jdk-11.0.6_windows-x64_bin.zip", Windows, Some(SAP)),
+      Version("java", "11.0.6-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.6/sapmachine-jdk-11.0.6_osx-x64_bin.tar.gz", MacOSX, Some(SAP))
+    ).validate().insert()
+    Seq(Linux64, Windows, MacOSX).foreach(platform => removeVersion(candidate = "java", version = "11.0.4-sapmchn", platform))
+  }
 
+  @ChangeSet(order = "0002", id = "0002-add_sapmchn_13_0_2", author = "poad")
+  def migrate0002(implicit db: MongoDatabase) = {
+    List(
+      Version("java", "13.0.2-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-13.0.2/sapmachine-jdk-13.0.2_linux-x64_bin.tar.gz", Linux64, Some(SAP)),
+      Version("java", "13.0.2-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-13.0.2/sapmachine-jdk-13.0.2_windows-x64_bin.zip", Windows, Some(SAP)),
+      Version("java", "13.0.2-sapmchn", "https://github.com/SAP/SapMachine/releases/download/sapmachine-13.0.2/sapmachine-jdk-13.0.2_osx-x64_bin.tar.gz", MacOSX, Some(SAP))
+    ).validate().insert()
+  }
 }


### PR DESCRIPTION
Bump each JDKs
 - SapMachine to 11.0.6
 - Zulu 13 to 13.0.2
 - Zulu 11 to 11.0.6
 - Zulu 8 to 8u242
 - Amazon Corretto 11 to 11.0.6
 - Amazon Corretto 8 to 8u242
 - Liberica 13 to 13.0.2
 - Liberica 11 to 11.0.6
 - Liberica 8 to 8u242
 - java.net OpenJDK 13 to 13.0.2
 - AdoptOpenJDK 11(hotspot) to 11.0.6
 - AdoptOpenJDK 11(OpenJ9) to 11.0.6
