### PR TITLE
Update AmazonCorrettoMigrations.scala

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/java/AmazonCorrettoMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/AmazonCorrettoMigrations.scala
@@ -75,4 +75,32 @@ class AmazonCorrettoMigrations {
         removeVersion(candidate = "java", version = "11.0.5-amzn", platform)
     )
   }
+  
+  @ChangeSet(
+    order = "0003",
+    id = "0003-add_corretto_java11_update_6_hotfix",
+    author = "dr29bart"
+  )
+  def migrate0003(implicit db: MongoDatabase) = {
+    Seq(MacOSX, Windows).foreach(
+      platform =>
+        removeVersion(candidate = "java", version = "11.0.6-amzn", platform)
+    )
+    List(
+      Version(
+        "java",
+        "11.0.6-amzn",
+        "https://corretto.aws/downloads/resources/11.0.6.10.1/amazon-corretto-11.0.6.10.1-2-macosx-x64.tar.gz",
+        MacOSX,
+        Some(Amazon)
+      ),
+      Version(
+        "java",
+        "11.0.6-amzn",
+        "https://corretto.aws/downloads/resources/11.0.6.10.1/amazon-corretto-11.0.6.10.1-1-windows-x64-jdk.zip",
+        Windows,
+        Some(Amazon)
+      )
+    ).validate().insert()
+  }
 }


### PR DESCRIPTION
Updated jdk contains fix for https://github.com/corretto/corretto-11/issues/73