### PR TITLE
Set 11.0.7.hs-adpt as default Java candidate

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/java/AdoptOpenJdkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/AdoptOpenJdkMigrations.scala
@@ -555,4 +555,13 @@ class AdoptOpenJdkMigrations {
       removeVersion("java", "14.0.0.hs-adpt", _)
     )
   }
+
+  @ChangeSet(
+    order = "0017",
+    id = "0017-set_adoptopenjdk_11.0.7.hs_as_default",
+    author = "vpavic"
+  )
+  def migrate0017(implicit db: MongoDatabase) =
+    setCandidateDefault("java", "11.0.7.hs-adpt")
+
 }


### PR DESCRIPTION
Current Java default candidate is outdated:

```
$ sdk ug

Upgrade:
java (11.0.7.j9-adpt, 8.0.252.hs-adpt, 14.0.1.hs-adpt, 14.0.1.j9-adpt, 8.0.252.j9-adpt, 11.0.7.hs-adpt < 11.0.6.hs-adpt)

Upgrade candidate(s) and set latest version(s) as default? (Y/n): 
```