### PR TITLE
Fix the SapMachine JDK for macOS download URL was wrong

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/java/SapMachineMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/SapMachineMigrations.scala
@@ -153,4 +153,28 @@ class SapMachineMigrations {
     )
   }
 
+  @ChangeSet(
+    order = "0006",
+    id = "0006-remove_sapmchn_jre_14_0_1",
+    author = "poad"
+  )
+  def migrate0006(implicit db: MongoDatabase) = {
+    Seq(MacOSX).foreach(
+      platform =>
+        removeVersion(candidate = "java", version = "14.0.1-sapmchn", platform)
+    )
+  }
+
+  @ChangeSet(order = "0007", id = "0007-re-add_sapmchn_14_0_1", author = "poad")
+  def migrate0007(implicit db: MongoDatabase) = {
+    List(
+      Version(
+        "java",
+        "14.0.1-sapmchn",
+        "https://github.com/SAP/SapMachine/releases/download/sapmachine-14.0.1/sapmachine-jdk-14.0.1_osx-x64_bin.tar.gz",
+        MacOSX,
+        Some(SAP)
+      )
+    ).validate().insert()
+  }
 }

--- a/src/main/scala/io/sdkman/changelogs/java/SapMachineMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/SapMachineMigrations.scala
@@ -177,4 +177,29 @@ class SapMachineMigrations {
       )
     ).validate().insert()
   }
+
+  @ChangeSet(
+    order = "0008",
+    id = "0008-remove_sapmchn_jre_11_0_7",
+    author = "poad"
+  )
+  def migrate0008(implicit db: MongoDatabase) = {
+    Seq(MacOSX).foreach(
+      platform =>
+        removeVersion(candidate = "java", version = "11.0.7-sapmchn", platform)
+    )
+  }
+
+  @ChangeSet(order = "0009", id = "0009-re-add_sapmchn_11.0.7", author = "poad")
+  def migrate0009(implicit db: MongoDatabase) = {
+    List(
+      Version(
+        "java",
+        "11.0.7-sapmchn",
+        "https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.7/sapmachine-jdk-11.0.7_osx-x64_bin.tar.gz",
+        MacOSX,
+        Some(SAP)
+      )
+    ).validate().insert()
+  }
 }


### PR DESCRIPTION
The download URL for '11.0.7-sapmchn' for macOS was from JRE.
Delete it and add the URL of the JDK.