### PR TITLE
Readd the OpenJDK 14.0.2

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
@@ -15,33 +15,6 @@ import io.sdkman.changelogs.{
 class OpenJdkMigrations {
 
   @ChangeSet(
-    order = "056",
-    id = "056-add_openjdk_java_14.0.2",
-    author = "eddumelendez"
-  )
-  def migrate056(implicit db: MongoDatabase): Unit =
-    Map(
-      Linux64 -> "openjdk-14.0.2_linux-x64_bin.tar.gz",
-      MacOSX  -> "openjdk-14.0.2_osx-x64_bin.tar.gz",
-      Windows -> "openjdk-14.0.2_windows-x64_bin.zip"
-    ).map {
-        case (platform, binary) =>
-          Version(
-            "java",
-            "14.0.2-open",
-            s"https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/11/GPL/$binary",
-            platform,
-            Some(OpenJDK)
-          )
-      }
-      .toList
-      .validate()
-      .insert()
-      .foreach { version =>
-        removeVersion("java", "14.0.1-open", version.platform)
-      }
-
-  @ChangeSet(
     order = "059",
     id = "059-add_openjdk_java_15-ea-32",
     author = "eddumelendez"

--- a/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
@@ -67,4 +67,41 @@ class OpenJdkMigrations {
       .foreach { version =>
         removeVersion("java", "16.ea.5-open", version.platform)
       }
+  @ChangeSet(
+    order = "061",
+    id = "061-remove_openjdk_java_14.0.2-b11",
+    author = "poad"
+  )
+  def migrate061(implicit db: MongoDatabase): Unit =
+    Seq(
+      Linux64,
+      MacOSX,
+      Windows
+    ).foreach { platform =>
+      removeVersion("java", "14.0.2-open", platform)
+    }
+
+  @ChangeSet(
+    order = "062",
+    id = "062-readd_openjdk_java_14.0.2",
+    author = "poad"
+  )
+  def migrate062(implicit db: MongoDatabase): Unit =
+    Map(
+      Linux64 -> "openjdk-14.0.2_linux-x64_bin.tar.gz",
+      MacOSX  -> "openjdk-14.0.2_osx-x64_bin.tar.gz",
+      Windows -> "openjdk-14.0.2_windows-x64_bin.zip"
+    ).map {
+        case (platform, binary) =>
+          Version(
+            "java",
+            "14.0.2-open",
+            s"https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/$binary",
+            platform,
+            Some(OpenJDK)
+          )
+      }
+      .toList
+      .validate()
+      .insert()
 }


### PR DESCRIPTION
OpenJDK 14.0.2's build number has changed from 11 to 12.
The download URL has also been changed.

To change to the new download URL, remove the original changeset and add a new URL changeset.