### PR TITLE
Correction of linux arm64 version labels of 11, 14

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/java/BellSoftLibericaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/BellSoftLibericaMigrations.scala
@@ -238,4 +238,30 @@ class BellSoftLibericaMigrations {
       .insert()
   }
 
+  @ChangeSet(
+    order = "0024",
+    id = "0024-correcting_linuxarm64_bellsoft_labels-11-14",
+    author = "dvdkruk"
+  )
+  def migrate0024(implicit db: MongoDatabase): Unit = {
+    Map(
+      "11.0.8-librca" -> "11.0.8+10/bellsoft-jdk11.0.8+10-linux-aarch64.tar.gz",
+      "14.0.2-librca" -> "14.0.2+13/bellsoft-jdk14.0.2+13-linux-aarch64.tar.gz"
+    ).map {
+        case (version, binary) =>
+          Version(
+            "java",
+            version,
+            s"https://download.bell-sw.com/java/$binary",
+            LinuxARM64,
+            Some(Liberica)
+          )
+      }
+      .toList
+      .validate()
+      .insert()
+    removeVersion("java", "11.0.8.librca", LinuxARM64)
+    removeVersion("java", "14.0.2.librca", LinuxARM64)
+  }
+
 }


### PR DESCRIPTION
Hey @eddumelendez, found that I made a typo in #319 for the non FX versions. This results in alignment issues in the UI/CLI:
![image](https://user-images.githubusercontent.com/2829407/91821991-80d79a00-ec7a-11ea-91d0-3ec028eac098.png)
This PR removes the typos and replaces them with the right version ids.