### PR TITLE
Dev support for vscode on Linux ARM64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,7 +94,7 @@ modules.xml
 ### Metals ###
 .metals/
 
-### Metals ###
+### VSCode ###
 .vscode/
 
 ### Scala ###

--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,9 @@ modules.xml
 ### Metals ###
 .metals/
 
+### Metals ###
+.vscode/
+
 ### Scala ###
 *.class
 *.log

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ This enables the users of SDKMAN to contribute new Installation Candidates and r
 
 This repo uses [mongobee](https://github.com/mongobee/mongobee) as database migration framework. In order to contribute a PR, it is required to have a local installation of MongoDB on your machine. Alternatively run it up with Docker (works on Linux):
 
-        $ docker run -d --network=host --name=mongo mongo:3.2
+        $ docker run -d --network=host --name=mongo mongo:4.0
 
 **Docker Desktop for Mac**
 
 To connect to MongoDB when using Docker Desktop for Mac you need to forward the port explicitly:
 
-        $ docker run -d -p 27017:27017 --name=mongo mongo:3.2
+        $ docker run -d -p 27017:27017 --name=mongo mongo:4.0
 
 ## The Build
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ This enables the users of SDKMAN to contribute new Installation Candidates and r
 
 This repo uses [mongobee](https://github.com/mongobee/mongobee) as database migration framework. In order to contribute a PR, it is required to have a local installation of MongoDB on your machine. Alternatively run it up with Docker (works on Linux):
 
-        $ docker run -d --network=host --name=mongo mongo:4.0
+        $ docker run -d --network=host --name=mongo mongo:3.2
 
 **Docker Desktop for Mac**
 
 To connect to MongoDB when using Docker Desktop for Mac you need to forward the port explicitly:
 
-        $ docker run -d -p 27017:27017 --name=mongo mongo:4.0
+        $ docker run -d -p 27017:27017 --name=mongo mongo:3.2
 
 ## The Build
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-  compile 'org.scala-lang:scala-library:2.12.4'
+  compile 'org.scala-lang:scala-library:2.12.12'
   compile 'org.javassist:javassist:3.18.2-GA'
   compile 'com.github.mongobee:mongobee:0.13'
   compile 'com.typesafe:config:1.3.1'


### PR DESCRIPTION
I had to do the following changes to make development with vscode on Linux ARM64 possible on this repo:
- Updated Scale to version 2.12.12 (min supported Scala version in metals)
- Updated README to use docker container `mongo:4.0` (as this version and up have ARM64 support)
- Git ignore `.vscode` dir

Contributing this back, so that the next person doesn't have to 😉