### PR TITLE
Add OpenJDK 16ea18 (#329)

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
@@ -162,9 +162,33 @@ class OpenJdkMigrations {
       }
 
   @ChangeSet(
+    order = "078",
+    id = "078-add_openjdk_java_16-loom-6",
+    author = "soberich"
+  )
+  def migrate078(implicit db: MongoDatabase): Unit =
+    Map(
+      Linux64 -> "openjdk-16-loom+6-105_linux-x64_bin.tar.gz",
+      MacOSX  -> "openjdk-16-loom+6-105_osx-x64_bin.tar.gz",
+      Windows -> "openjdk-16-loom+6-105_windows-x64_bin.zip"
+    ).map {
+        case (platform, binary) =>
+          Version(
+            "java",
+            "16.ea.6.lm-open",
+            s"https://download.java.net/java/early_access/loom/6/$binary",
+            platform,
+            Some(OpenJDK)
+          )
+      }
+      .toList
+      .validate()
+      .insert()
+
+  @ChangeSet(
     order = "079",
     id = "079-add_openjdk_java_16-ea-18",
-    author = "eddumelendez"
+    author = "govi20"
   )
   def migrate079(implicit db: MongoDatabase): Unit =
     Map(
@@ -188,28 +212,4 @@ class OpenJdkMigrations {
       .foreach { version =>
         removeVersion("java", "16.ea.17-open", version.platform)
       }
-
-  @ChangeSet(
-    order = "078",
-    id = "078-add_openjdk_java_16-loom-6",
-    author = "soberich"
-  )
-  def migrate078(implicit db: MongoDatabase): Unit =
-    Map(
-      Linux64 -> "openjdk-16-loom+6-105_linux-x64_bin.tar.gz",
-      MacOSX  -> "openjdk-16-loom+6-105_osx-x64_bin.tar.gz",
-      Windows -> "openjdk-16-loom+6-105_windows-x64_bin.zip"
-    ).map {
-        case (platform, binary) =>
-          Version(
-            "java",
-            "16.ea.6.lm-open",
-            s"https://download.java.net/java/early_access/loom/6/$binary",
-            platform,
-            Some(OpenJDK)
-          )
-      }
-      .toList
-      .validate()
-      .insert()
 }

--- a/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
@@ -162,22 +162,22 @@ class OpenJdkMigrations {
       }
 
   @ChangeSet(
-    order = "077",
-    id = "077-add_openjdk_java_16-ea-17",
+    order = "079",
+    id = "079-add_openjdk_java_16-ea-18",
     author = "eddumelendez"
   )
-  def migrate077(implicit db: MongoDatabase): Unit =
+  def migrate079(implicit db: MongoDatabase): Unit =
     Map(
-      LinuxARM64 -> "openjdk-16-ea+17_linux-aarch64_bin.tar.gz",
-      Linux64    -> "openjdk-16-ea+17_linux-x64_bin.tar.gz",
-      MacOSX     -> "openjdk-16-ea+17_osx-x64_bin.tar.gz",
-      Windows    -> "openjdk-16-ea+17_windows-x64_bin.zip"
+      LinuxARM64 -> "openjdk-16-ea+18_linux-aarch64_bin.tar.gz",
+      Linux64    -> "openjdk-16-ea+18_linux-x64_bin.tar.gz",
+      MacOSX     -> "openjdk-16-ea+18_osx-x64_bin.tar.gz",
+      Windows    -> "openjdk-16-ea+18_windows-x64_bin.zip"
     ).map {
         case (platform, binary) =>
           Version(
             "java",
-            "16.ea.17-open",
-            s"https://download.java.net/java/early_access/jdk16/17/GPL/$binary",
+            "16.ea.18-open",
+            s"https://download.java.net/java/early_access/jdk16/18/GPL/$binary",
             platform,
             Some(OpenJDK)
           )
@@ -186,7 +186,7 @@ class OpenJdkMigrations {
       .validate()
       .insert()
       .foreach { version =>
-        removeVersion("java", "16.ea.16-open", version.platform)
+        removeVersion("java", "16.ea.17-open", version.platform)
       }
 
   @ChangeSet(


### PR DESCRIPTION
This PR adds OpenJDK early access version 18 (https://download.java.net/java/early_access/jdk16/18/GPL/{binary_file})