### PR TITLE
Fail build if code incorrectly formated.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,4 +23,4 @@ dependencies {
   runtime 'org.slf4j:slf4j-simple:1.7.25'
 }
 
-compileScala.dependsOn("scalafmt")
+compileScala.dependsOn("checkScalafmt")


### PR DESCRIPTION
Runs `checkScalafmt` instead of `scalafmt` as dependent task on `compileScala`.

