### PR TITLE
Update event type to pull_request_target for action.xml

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,7 +1,7 @@
 ---
 # yamllint disable-line rule:truthy
 name: 'Auto Assign'
-on: pull_request
+on: pull_request_target
 
 jobs:
   add-reviews:


### PR DESCRIPTION
Currently, when a PR is submitted by contributor from their own
fork, action is not running properly. In order to allow that
the action must use event `pull_request_target`.
