### PR TITLE
Remove old OpenJDK 8 & 11 binaries

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
@@ -208,4 +208,15 @@ class OpenJdkMigrations {
         removeVersion("java", "16.ea.22-open", version.platform)
       }
 
+  @ChangeSet(
+    order = "087",
+    id = "087-remove-java.net-openjdk-11-8-binaries",
+    author = "andrebrait"
+  )
+  def migrate087(implicit db: MongoDatabase): Unit =
+    List(Linux64, Windows)
+      .foreach { platform =>
+        removeVersion("java", "8.0.265-open", platform)
+        removeVersion("java", "11.0.2-open", platform)
+      }
 }

--- a/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/OpenJdkMigrations.scala
@@ -209,11 +209,11 @@ class OpenJdkMigrations {
       }
 
   @ChangeSet(
-    order = "087",
-    id = "087-remove-java.net-openjdk-11-8-binaries",
+    order = "088",
+    id = "088-remove-java.net-openjdk-11-8-binaries",
     author = "andrebrait"
   )
-  def migrate087(implicit db: MongoDatabase): Unit =
+  def migrate088(implicit db: MongoDatabase): Unit =
     List(Linux64, Windows)
       .foreach { platform =>
         removeVersion("java", "8.0.265-open", platform)


### PR DESCRIPTION
Explaining the rationaly:

Given the new AdoptOpenJDK Upstream binaries are now the official binary builds of OpenJDK (with https://wiki.openjdk.java.net/display/jdk8u/Main even pointing at the GitHub-hosted binaries from AdoptOpenJDK's Upstream repositories), it's inconsistent to provide any releases under `*-open` at the same time we provide them under `*.open-adpt`.

Given we are providing OpenJDK 8 and OpenJDK 11 under `.open-adpt`, I want to remove the corresponding major releases from the `-open` options, as the ones from Java.net are outdated and superseded by those we now provide under AdoptOpenJDK's Upstream builds.