### PR TITLE
Add TravaOpenJdk

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/java/TravaOpenJdkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/TravaOpenJdkMigrations.scala
@@ -1,0 +1,65 @@
+package io.sdkman.changelogs.java
+
+import com.github.mongobee.changeset.{ChangeLog, ChangeSet}
+import com.mongodb.client.MongoDatabase
+import io.sdkman.changelogs.{TravaOpenJdk, Linux64, MacOSX, Version, Windows}
+
+@ChangeLog(order = "040")
+class TravaOpenJdkMigrations {
+
+  @ChangeSet(
+    order = "001",
+    id = "001-add_TravaOpenJdk-8_0_232",
+    author = "brunoRoemers"
+  )
+  def migrate001(implicit db: MongoDatabase): Unit = {
+    List(
+      Version(
+        "java",
+        "8.0.232-trava",
+        "https://github.com/TravaOpenJDK/trava-jdk-8-dcevm/releases/download/dcevm8u232b09/java8-openjdk-dcevm-linux.tar.gz",
+        Linux64,
+        Some(TravaOpenJdk)
+      ),
+      Version(
+        "java",
+        "8.0.232-trava",
+        "https://github.com/TravaOpenJDK/trava-jdk-8-dcevm/releases/download/dcevm8u232b09/java8-openjdk-dcevm-osx.tar.gz",
+        MacOSX,
+        Some(TravaOpenJdk)
+      )
+    ).validate().insert()
+  }
+
+  @ChangeSet(
+    order = "002",
+    id = "002-add_TravaOpenJdk-11_0_9",
+    author = "brunoRoemers"
+  )
+  def migrate002(implicit db: MongoDatabase): Unit = {
+    List(
+      Version(
+        "java",
+        "11.0.9-trava",
+        "https://github.com/TravaOpenJDK/trava-jdk-11-dcevm/releases/download/dcevm-11.0.9%2B1/java11-openjdk-dcevm-linux.tar.gz",
+        Linux64,
+        Some(TravaOpenJdk)
+      ),
+      Version(
+        "java",
+        "11.0.9-trava",
+        "https://github.com/TravaOpenJDK/trava-jdk-11-dcevm/releases/download/dcevm-11.0.9%2B1/java11-openjdk-dcevm-osx.tar.gz",
+        MacOSX,
+        Some(TravaOpenJdk)
+      ),
+      Version(
+        "java",
+        "11.0.9-trava",
+        "https://github.com/TravaOpenJDK/trava-jdk-11-dcevm/releases/download/dcevm-11.0.9%2B1/java11-openjdk-dcevm-windows.zip",
+        Windows,
+        Some(TravaOpenJdk)
+      )
+    ).validate().insert()
+  }
+
+}

--- a/src/main/scala/io/sdkman/changelogs/package.scala
+++ b/src/main/scala/io/sdkman/changelogs/package.scala
@@ -130,6 +130,10 @@ package object changelogs {
     override def id = "sapmchn"
   }
 
+  case object TravaOpenJdk extends Vendor {
+    override def id = "trava"
+  }
+
   case object Zulu extends Vendor {
     override def id = "zulu"
   }


### PR DESCRIPTION
TravaOpenJDK (https://github.com/TravaOpenJDK/trava-jdk-11-dcevm) builds AdoptOpenJDK with DCEVM enabled. DCEVM provides better hot swapping capabilities to Java HotSpot JVM (e.g. add/remove methods, redefine signatures... without full rebuild). It can be used in conjunction with HotSwapAgent to better integrate with various application frameworks (Spring, Hibernate...).

Looking at https://github.com/sdkman/sdkman-db-migrations/pull/413, I figured https://github.com/sdkman/sdkman-candidates/pull/19 will be needed as well.