### PR TITLE
Update default Java candidate

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/java/AdoptOpenJdkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/AdoptOpenJdkMigrations.scala
@@ -1136,4 +1136,13 @@ class AdoptOpenJdkMigrations {
       "15.0.1.hs-adpt",
       "15.0.1.j9-adpt"
     ).foreach(version => hideVersion("java", version))
+
+  @ChangeSet(
+    order = "054",
+    id = "054-update-default-candidate",
+    author = "vpavic"
+  )
+  def migrate054(implicit db: MongoDatabase): Unit =
+    setCandidateDefault("java", "11.0.10.hs-adpt")
+
 }


### PR DESCRIPTION
At present, this happens when using `upgrade` command with all the latest AdoptOpenJDK releases installed:

```
$ sdk ug

Upgrade:
java (21.0.0.r11-grl, 8.0.282.hs-adpt, 15.0.2.hs-adpt, 11.0.10.hs-adpt < 11.0.9.hs-adpt)

Upgrade candidate(s) and set latest version(s) as default? (Y/n):
```

This PR sets `11.0.10.hs-adpt` as the default Java candidate.