### PR TITLE
Update default Java candidate

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/java/AdoptOpenJdkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/java/AdoptOpenJdkMigrations.scala
@@ -1165,4 +1165,12 @@ class AdoptOpenJdkMigrations {
       .insert()
       .foreach(version => hideVersion("java", version.version))
 
+  @ChangeSet(
+    order = "059",
+    id = "059-update-default-candidate",
+    author = "nickebbitt"
+  )
+  def migrate059(implicit db: MongoDatabase): Unit =
+    setCandidateDefault("java", "11.0.11.hs-adpt")
+
 }


### PR DESCRIPTION
Sets 11.0.11.hs-adpt as the default Java candidate. 11.0.11 is the most recent patch release for the current LTS.