### PR TITLE
Adding new candidate for MyBatis Migrations as migrate

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/MyBatisMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/MyBatisMigrations.scala
@@ -5,6 +5,9 @@ import com.mongodb.client.MongoDatabase
 
 @ChangeLog(order = "062")
 class MyBatisMigrations {
+
+  val CandidateName = "mybatis"
+
   @ChangeSet(
     order = "001",
     id = "001-add_mybatis_migrations_candidate",
@@ -12,10 +15,10 @@ class MyBatisMigrations {
   )
   def migration001(implicit db: MongoDatabase) = {
     Candidate(
-      candidate = "migrate",
-      name = "Apache MyBatis Migrations",
+      candidate = CandidateName,
+      name = "MyBatis Migrations",
       description =
-        "The MyBatis Schema Migration System (or MyBatis Migrations for short) seeks to provide database migrations for any database (new or existing) and make the current status of the database easily accessible and comprehensible.",
+        "The MyBatis Schema Migration System (or MyBatis Migrations for short) seeks to provide database migrations for any database (new or existing) and make the current status of the database easily accessible and comprehensible. Installing this candidate provides the migrate command for managing database migrations",
       websiteUrl = "https://mybatis.org/migrations/",
       distribution = "UNIVERSAL"
     ).insert()
@@ -42,7 +45,7 @@ class MyBatisMigrations {
     ).map(
         version =>
           Version(
-            candidate = "migrate",
+            candidate = CandidateName,
             version = version,
             url =
               s"https://github.com/mybatis/migrations/releases/download/mybatis-migrations-$version/mybatis-migrations-$version-bundle.zip"
@@ -66,7 +69,7 @@ class MyBatisMigrations {
     ).map(
         version =>
           Version(
-            candidate = "migrate",
+            candidate = CandidateName,
             version = version,
             url =
               s"https://github.com/mybatis/migrations/releases/download/mybatis-migrations-$version/mybatis-migrations-$version.zip"


### PR DESCRIPTION
Adding new candidate as `migrate` for [MyBatis Migrations](https://mybatis.org/migrations/) a tool that helps manage database migrations via sql scripts and a command line