### PR TITLE
Update Tomcat versions to the latest

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
+++ b/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
@@ -29,10 +29,10 @@ class TomcatMigration {
   def migration007(implicit db: MongoDatabase) = {
     removeAllVersions("tomcat")
     List(
-      "7"  -> "7.0.106",
-      "8"  -> "8.5.60",
-      "9"  -> "9.0.40",
-      "10" -> "10.0.0-M10"
+      "7"  -> "7.0.109",
+      "8"  -> "8.5.73",
+      "9"  -> "9.0.55",
+      "10" -> "10.0.13"
     ).map {
         case (series: String, version: String) =>
           Version(
@@ -44,6 +44,6 @@ class TomcatMigration {
       }
       .validate()
       .insert()
-    setCandidateDefault("tomcat", "9.0.40")
+    setCandidateDefault("tomcat", "10.0.13")
   }
 }


### PR DESCRIPTION
Updated the versions of Apache Tomcat to the latest versions for series 7 -> 7.0.109, 8.5 -> 8.5.73, 9 -> 9.0.55, and 10 -> 10.0.13.  Also updated the default candidate from 9 to 10 since 10 has been officially released now.