### PR TITLE
Support Linux ARM32 variants.

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/package.scala
+++ b/src/main/scala/io/sdkman/changelogs/package.scala
@@ -182,8 +182,12 @@ package object changelogs {
     override val id = "LINUX_ARM64"
   }
 
-  case object LinuxARM32 extends Platform {
-    override val id = "LINUX_ARM32"
+  case object LinuxARM32SF extends Platform {
+    override val id = "LINUX_ARM32SF"
+  }
+
+  case object LinuxARM32HF extends Platform {
+    override val id = "LINUX_ARM32HF"
   }
 
   case class Candidate(


### PR DESCRIPTION
Add support for `LINUX_ARM32SF` and `LINUX_ARM32HF` platforms and retires `LINUX_ARM32`.
