### PR TITLE
Fix formatting of maven-4-alpha-1 changeset

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/MavenMigration.scala
+++ b/src/main/scala/io/sdkman/changelogs/MavenMigration.scala
@@ -16,7 +16,11 @@ class MavenMigration {
       .asCandidateDefault()
   }
 
-  @ChangeSet(order = "009", id = "009-add_maven_4.0.0-alpha-1", author = "helpermethod")
+  @ChangeSet(
+    order = "009",
+    id = "009-add_maven_4.0.0-alpha-1",
+    author = "helpermethod"
+  )
   def migration009(implicit db: MongoDatabase) = {
     Version(
       "maven",

--- a/src/main/scala/io/sdkman/changelogs/MavenMigration.scala
+++ b/src/main/scala/io/sdkman/changelogs/MavenMigration.scala
@@ -29,5 +29,4 @@ class MavenMigration {
     ).validate()
       .insert()
   }
-
 }


### PR DESCRIPTION
This PR should fix the broken formatting of the MavenMigration.scala file (which somehow broke master).