### PR TITLE
Add Spark 3.2.2, 3.3.0, and 3.3.1

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/SparkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/SparkMigrations.scala
@@ -6,31 +6,45 @@ import com.mongodb.client.MongoDatabase
 @ChangeLog(order = "007")
 class SparkMigrations {
   @ChangeSet(
-    order = "017",
-    id = "016-add_spark_3.2.0",
-    author = "ChethanUK"
+    order = "020",
+    id = "020-add_spark_3.2.2",
+    author = "cphbrt"
   )
-  def migration017(implicit db: MongoDatabase): Unit = {
+  def migration020(implicit db: MongoDatabase) = {
     Version(
       "spark",
-      "3.2.0",
-      "https://archive.apache.org/dist/spark/spark-3.2.0/spark-3.2.0-bin-hadoop3.2.tgz"
+      "3.2.2",
+      "https://archive.apache.org/dist/spark/spark-3.2.2/spark-3.2.2-bin-hadoop3.2.tgz"
     ).validate()
       .insert()
-      .asCandidateDefault()
   }
 
   @ChangeSet(
-    order = "019",
-    id = "019-add_spark_3.2.1",
-    author = "ChethanUK"
+    order = "021",
+    id = "021-add_spark_3.3.0",
+    author = "cphbrt"
   )
-  def migration019(implicit db: MongoDatabase) = {
+  def migration021(implicit db: MongoDatabase) = {
     Version(
       "spark",
-      "3.2.1",
-      "https://archive.apache.org/dist/spark/spark-3.2.1/spark-3.2.1-bin-hadoop3.2.tgz"
+      "3.3.0",
+      "https://archive.apache.org/dist/spark/spark-3.3.0/spark-3.3.0-bin-hadoop3.tgz"
     ).validate()
       .insert()
+  }
+
+  @ChangeSet(
+    order = "022",
+    id = "022-add_spark_3.3.1",
+    author = "cphbrt"
+  )
+  def migration022(implicit db: MongoDatabase) = {
+    Version(
+      "spark",
+      "3.3.1",
+      "https://archive.apache.org/dist/spark/spark-3.3.1/spark-3.3.1-bin-hadoop3.tgz"
+    ).validate()
+      .insert()
+      .asCandidateDefault()
   }
 }


### PR DESCRIPTION
This is my first contribution to this repository, so please advise on any style or process mistakes.

An existing PR is open for 3.3.0 but is stalled: https://github.com/sdkman/sdkman-db-migrations/pull/605

The `./gradlew clean run` completes successfully on my machine with this PR's changes, but I had to use the command `docker run -d -p 27017:27017 --name=mongo arm64v8/mongo:4.0.28` to setup Mongo on my machine, which differs from the example on the README because I am on Apple silicon and Docker Hub doesn't have a mongo `3.2` for `arm64`.

I did _not_ test if the `sdk install spark 3.3.1` will succeed with this PR's changes, because I am not sure how to hook up my local SDKMAN with the mongoDB container...

So, tl;dr, I followed the patterns I see in Git closely. Happy to change, test, or add anything you advise.

Thanks!

PS: I got the new Spark version URLs from here: https://archive.apache.org/dist/spark/

You may notice that the end of the URL switched from `3.2.tgz` to `3.tgz` at Spark `3.3.X`. It looks comparably harmless to the change from `2.7.tgz` to `3.2.tgz` that occurred several commits ago in this repo.