### PR TITLE
Add current tomcat versions and remove EOL ones

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
+++ b/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
@@ -72,4 +72,37 @@ class TomcatMigration {
     ).validate()
       .insert()
       .asCandidateDefault()
+
+  @ChangeSet(
+    order = "010",
+    id = "010-update_tomcat_versions",
+    author = "stefanpenndorf"
+  )
+  def migration010(implicit db: MongoDatabase): Document = {
+    removeVersion("tomcat", "7.0.106")
+    removeVersion("tomcat", "7.0.109")
+    removeVersion("tomcat", "10.0.0-M10")
+    removeVersion("tomcat", "10.0.14")
+    removeVersion("tomcat", "10.0.22")
+    removeVersion("tomcat", "10.1.0-M8")
+
+    List(
+      "8"  -> "8.5.85",
+      "9"  -> "9.0.65",
+      "9"  -> "9.0.71",
+      "10" -> "10.1.5",
+      "11" -> "11.0.0-M1"
+    ).map {
+        case (series: String, version: String) =>
+          Version(
+            candidate = "tomcat",
+            version = version,
+            url =
+              s"https://archive.apache.org/dist/tomcat/tomcat-$series/v$version/bin/apache-tomcat-$version.zip"
+          )
+      }
+      .validate()
+      .insert()
+    setCandidateDefault("tomcat", "10.1.5")
+  }
 }

--- a/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
+++ b/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
@@ -79,18 +79,17 @@ class TomcatMigration {
     author = "stefanpenndorf"
   )
   def migration010(implicit db: MongoDatabase): Document = {
-    removeVersion("tomcat", "7.0.106")
-    removeVersion("tomcat", "7.0.109")
     removeVersion("tomcat", "10.0.0-M10")
-    removeVersion("tomcat", "10.0.14")
-    removeVersion("tomcat", "10.0.22")
     removeVersion("tomcat", "10.1.0-M8")
 
     List(
       "8"  -> "8.5.86",
+      "8"  -> "8.5.87",
       "9"  -> "9.0.65",
       "9"  -> "9.0.72",
+      "9"  -> "9.0.73",
       "10" -> "10.1.6",
+      "10" -> "10.1.7",
       "11" -> "11.0.0-M3"
     ).map {
         case (series: String, version: String) =>
@@ -103,6 +102,6 @@ class TomcatMigration {
       }
       .validate()
       .insert()
-    setCandidateDefault("tomcat", "10.1.6")
+    setCandidateDefault("tomcat", "10.1.7")
   }
 }

--- a/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
+++ b/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
@@ -87,11 +87,11 @@ class TomcatMigration {
     removeVersion("tomcat", "10.1.0-M8")
 
     List(
-      "8"  -> "8.5.85",
+      "8"  -> "8.5.86",
       "9"  -> "9.0.65",
-      "9"  -> "9.0.71",
-      "10" -> "10.1.5",
-      "11" -> "11.0.0-M1"
+      "9"  -> "9.0.72",
+      "10" -> "10.1.6",
+      "11" -> "11.0.0-M3"
     ).map {
         case (series: String, version: String) =>
           Version(
@@ -103,6 +103,6 @@ class TomcatMigration {
       }
       .validate()
       .insert()
-    setCandidateDefault("tomcat", "10.1.5")
+    setCandidateDefault("tomcat", "10.1.6")
   }
 }


### PR DESCRIPTION
Updated the tomcat versions to the latest versions available and removed old, obsolete ones.

- Adding latest Versions of Tomcat 8 - 11
- Removed obsolete Tomcat 7 which is EOL since 2021
- Removed obsolete Tomcat 10.0 that is EOL since End of January 2023
- Removed 10.1.0-M8 milestone version that was superseded by final 10.1 version

