### PR TITLE
Fixes Maven Daemon github URL

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/MavenDaemon.scala
+++ b/src/main/scala/io/sdkman/changelogs/MavenDaemon.scala
@@ -16,6 +16,6 @@ class MavenDaemon {
       name = "Maven Daemon",
       description =
         "The mvnd project aims to provide a daemon infrastructure for maven based builds. It borrows techniques from Gradle and Takari to provide a simple and efficient system.",
-      websiteUrl = "https://github.com/mvndaemon/mvnd/"
+      websiteUrl = "https://github.com/apache/maven-mvnd/"
     ).insert()
 }


### PR DESCRIPTION
Maven Daemon has been relocated from its own repository at `https://github.com/apache/maven-mvnd` to a repository under the Apache organization. Due to the relocation no new versions appeared in SDKMAN!.

EDIT: I wasn't shure if changing the URL directly will work. If there is another way to change the candidates URL please let me know and I modify the pull request. The only URL change I could find in a short search was at https://github.com/sdkman/sdkman-db-migrations/commit/d74da64d8ed7117308feda241fb0887c37d5b18e#diff-cb39b8639a1a347ab9be9634d42001f4c21bd211494ee69431549469ee0814b4R78 when the URL scheme was modified from `http` to `https`.