### PR TITLE
Upgraded to Tomcat June release versions

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
+++ b/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
@@ -157,4 +157,31 @@ class TomcatMigration {
       .insert()
     setCandidateDefault("tomcat", "10.1.9")
   }
+
+  @ChangeSet(
+    order = "013",
+    id = "013-update_tomcat_versions",
+    author = "stefanpenndorf"
+  )
+  def migration013(implicit db: MongoDatabase): Document = {
+    removeVersion("tomcat", "11.0.0-M6")
+
+    List(
+      "8"  -> "8.5.90",
+      "9"  -> "9.0.76",
+      "10" -> "10.1.10",
+      "11" -> "11.0.0-M7"
+    ).map {
+        case (series: String, version: String) =>
+          Version(
+            candidate = "tomcat",
+            version = version,
+            url =
+              s"https://archive.apache.org/dist/tomcat/tomcat-$series/v$version/bin/apache-tomcat-$version.zip"
+          )
+      }
+      .validate()
+      .insert()
+    setCandidateDefault("tomcat", "10.1.10")
+  }
 }


### PR DESCRIPTION
This includes
- Tomcat 8.5.90 as latest from 8.5 line
- Tomcat 9.0.76 as latest from 9.0 line
- Tomcat 10.1.10 as latest from 10.1 line (will be new default version)
- Tomcat 11.0.0-M7 as latest from 11 line (this is the latest alpha release)

Tomcat 10.0.0-M6 dropped because it's only an alpha release and superseded by M7.