### PR TITLE
Use pull_request

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,6 @@
 name: Pull Requests
-on: pull_request_target
+on:
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
> Avoid using this event if you need to build or run code from the pull request.

According to the `pull_request_target`
[docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target)
