### PR TITLE
Upgraded to Tomcat Oktober security release

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
+++ b/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
@@ -214,4 +214,32 @@ class TomcatMigration {
       .insert()
     setCandidateDefault("tomcat", "10.1.12")
   }
+
+  @ChangeSet(
+    order = "015",
+    id = "015-update_tomcat_versions",
+    author = "stefanpenndorf"
+  )
+  def migration015(implicit db: MongoDatabase): Document = {
+    removeVersion("tomcat", "11.0.0-M10")
+
+    List(
+      "8"  -> "8.5.94",
+      "9"  -> "9.0.81",
+      "10" -> "10.1.14",
+      "11" -> "11.0.0-M12"
+    ).map {
+        case (series: String, version: String) =>
+          Version(
+            candidate = "tomcat",
+            version = version,
+            url =
+              s"https://archive.apache.org/dist/tomcat/tomcat-$series/v$version/bin/apache-tomcat-$version.zip"
+          )
+      }
+      .validate()
+      .insert()
+    setCandidateDefault("tomcat", "10.1.14")
+  }
+
 }


### PR DESCRIPTION
Fixes several Tomcat CVE:
- Important: Request smuggling CVE-2023-45648
- Important: Denial of Service CVE-2023-44487
- Important: Information Disclosure CVE-2023-42795
- Low: Denial of Service CVE-2023-42794

Upgrade includes
- Tomcat 8.5.94 from 8.5 line
- Tomcat 9.0.81 from 9.0 line
- Tomcat 10.1.14 from 10.1 line (will be new default version)
- Tomcat 11.0.0-M12 as latest from 11 line (this is the latest alpha release)

Tomcat 11.0.0-M10 dropped because it's only an alpha release and superseded by M10.