### PR TITLE
flink: add versions 1.17.1 and 1.18.0

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/FlinkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/FlinkMigrations.scala
@@ -36,14 +36,14 @@ class FlinkMigrations {
     s"https://archive.apache.org/dist/flink/flink-$version/flink-$version-bin-scala_$scala.tgz"
 
   @ChangeSet(
-    order = "010",
-    id = "010-add_flink_1_17",
-    author = "sekikn"
+    order = "011",
+    id = "011-add_flink_1_18",
+    author = "thomas-bouvier"
   )
   def migration010(implicit db: MongoDatabase) = {
     val flinkVersions = List(
-      "1.16.1",
-      "1.17.0"
+      "1.17.1",
+      "1.18.0"
     )
     List("2.12")
       .flatMap { scalaVersion =>
@@ -53,6 +53,6 @@ class FlinkMigrations {
       }
       .validate()
       .insert()
-    setCandidateDefault("flink", "1.17.0")
+    setCandidateDefault("flink", "1.18.0")
   }
 }


### PR DESCRIPTION
Hello all,

This is my first attempt at contributing to SDKMAN. Thank you for this great tool.

I'm trying to add Flink versions 1.17.1 and 1.18.0 but couldn't run `./gradlew clean run` locally on my machine. It seems that no Docker container gets launched. Should that be the case?

I get the following:

```
[main] INFO org.mongodb.driver.cluster - Cluster created with settings {hosts=[localhost:27017], mode=SINGLE, requiredClusterType=UNKNOWN, serverSelectionTimeout='30000 ms', maxWaitQueueSize=500}
[cluster-ClusterId{value='6542d1704842cfe48ed1ea22', description='null'}-localhost:27017] INFO org.mongodb.driver.cluster - Exception in monitor thread while connecting to server localhost:27017
com.mongodb.MongoSocketOpenException: Exception opening socket
        at com.mongodb.connection.SocketStream.open(SocketStream.java:63)
        at com.mongodb.connection.InternalStreamConnection.open(InternalStreamConnection.java:115)
        at com.mongodb.connection.DefaultServerMonitor$ServerMonitorRunnable.run(DefaultServerMonitor.java:116)
        at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.net.ConnectException: Connection refused
        at java.base/sun.nio.ch.Net.pollConnect(Native Method)
        at java.base/sun.nio.ch.Net.pollConnectNow(Net.java:672)
        at java.base/sun.nio.ch.NioSocketImpl.timedFinishConnect(NioSocketImpl.java:547)
        at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:602)
        at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327)
        at java.base/java.net.Socket.connect(Socket.java:633)
        at com.mongodb.connection.SocketStreamHelper.initialize(SocketStreamHelper.java:50)
        at com.mongodb.connection.SocketStream.open(SocketStream.java:58)
        ... 3 more
[main] INFO org.mongodb.driver.cluster - No server chosen by ReadPreferenceServerSelector{readPreference=primary} from cluster description ClusterDescription{type=UNKNOWN, connectionMode=SINGLE, serverDescriptions=[ServerDescription{address=localhost:27017, type=UNKNOWN, state=CONNECTING, exception={com.mongodb.MongoSocketOpenException: Exception opening socket}, caused by {java.net.ConnectException: Connection refused}}]}. Waiting for 30000 ms before timing out
```

I marked the PR as WIP.