### PR TITLE
Add Spark 3.4.1 and 3.5.0

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/SparkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/SparkMigrations.scala
@@ -48,4 +48,33 @@ class SparkMigrations {
       .insert()
       .asCandidateDefault()
   }
+
+  @ChangeSet(
+    order = "026",
+    id = "026-add_spark_3.4.1",
+    author = "cphbrt"
+  )
+  def migration026(implicit db: MongoDatabase) = {
+    Version(
+      "spark",
+      "3.4.1",
+      "https://archive.apache.org/dist/spark/spark-3.4.1/spark-3.4.1-bin-hadoop3.tgz"
+    ).validate()
+      .insert()
+  }
+
+  @ChangeSet(
+    order = "027",
+    id = "027-add_spark_3.5.0",
+    author = "cphbrt"
+  )
+  def migration027(implicit db: MongoDatabase) = {
+    Version(
+      "spark",
+      "3.5.0",
+      "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz"
+    ).validate()
+      .insert()
+      .asCandidateDefault()
+  }
 }


### PR DESCRIPTION
Hi! I contributed to these Spark migrations once before here (https://github.com/sdkman/sdkman-db-migrations/pull/614), so I followed the same pattern again in this PR.

Unfortunately, my local `./gradlew clean run` is failing with this:
```
Caused by: com.github.mongobee.exception.MongobeeChangeSetException: Invalid url: https://cdn.cuba-platform.com/cuba-cli/1.0.1/cuba-cli-1.0.1-linux.zip
```
but it appears unrelated to my changes, and the GitHub PR build succeeded, so hopefully that's not a blocker.

Thanks!