### PR TITLE
Adding Liquibase Candidate

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/LiquibaseMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/LiquibaseMigrations.scala
@@ -1,0 +1,13 @@
+@ChangeLog(order = "036")
+class LiquibaseMigrations {
+    @ChangeSet(order = "001", id = "001_add_liquibase_1_2_3", author = "jandroav")
+    def migration001(implicit db: MongoDatabase) = {
+        Candidate(
+          candidate = "liquibase",
+          name = "Liquibase",
+          description = "Innovate faster with database DevOps. Automated, secure, and compliant database change management pipelines that accelerate delivery and reduce toil",
+          websiteUrl = "https://liquibase.com/",
+          distribution = "UNIVERSAL"
+        ).insert()
+    }
+}

--- a/src/main/scala/io/sdkman/changelogs/LiquibaseMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/LiquibaseMigrations.scala
@@ -1,11 +1,11 @@
-@ChangeLog(order = "036")
+@ChangeLog(order = "085")
 class LiquibaseMigrations {
     @ChangeSet(order = "001", id = "001_add_liquibase_1_2_3", author = "jandroav")
     def migration001(implicit db: MongoDatabase) = {
         Candidate(
           candidate = "liquibase",
           name = "Liquibase",
-          description = "Innovate faster with database DevOps. Automated, secure, and compliant database change management pipelines that accelerate delivery and reduce toil",
+          description = "Liquibase is an open-source database-independent library for tracking, managing and applying database schema changes.",
           websiteUrl = "https://liquibase.com/",
           distribution = "UNIVERSAL"
         ).insert()

--- a/src/main/scala/io/sdkman/changelogs/LiquibaseMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/LiquibaseMigrations.scala
@@ -1,13 +1,14 @@
 @ChangeLog(order = "085")
 class LiquibaseMigrations {
-    @ChangeSet(order = "001", id = "001_add_liquibase_1_2_3", author = "jandroav")
-    def migration001(implicit db: MongoDatabase) = {
-        Candidate(
-          candidate = "liquibase",
-          name = "Liquibase",
-          description = "Liquibase is an open-source database-independent library for tracking, managing and applying database schema changes.",
-          websiteUrl = "https://liquibase.com/",
-          distribution = "UNIVERSAL"
-        ).insert()
-    }
+  @ChangeSet(order = "001", id = "001_add_liquibase_1_2_3", author = "jandroav")
+  def migration001(implicit db: MongoDatabase) = {
+    Candidate(
+      candidate = "liquibase",
+      name = "Liquibase",
+      description =
+        "Liquibase is an open-source database-independent library for tracking, managing and applying database schema changes.",
+      websiteUrl = "https://liquibase.com/",
+      distribution = "UNIVERSAL"
+    ).insert()
+  }
 }

--- a/src/main/scala/io/sdkman/changelogs/LiquibaseMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/LiquibaseMigrations.scala
@@ -1,3 +1,8 @@
+package io.sdkman.changelogs
+
+import com.github.mongobee.changeset.{ChangeLog, ChangeSet}
+import com.mongodb.client.MongoDatabase
+
 @ChangeLog(order = "085")
 class LiquibaseMigrations {
   @ChangeSet(order = "001", id = "001_add_liquibase_1_2_3", author = "jandroav")

--- a/src/main/scala/io/sdkman/changelogs/LiquibaseMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/LiquibaseMigrations.scala
@@ -5,7 +5,7 @@ import com.mongodb.client.MongoDatabase
 
 @ChangeLog(order = "085")
 class LiquibaseMigrations {
-  @ChangeSet(order = "001", id = "001_add_liquibase_1_2_3", author = "jandroav")
+  @ChangeSet(order = "001", id = "001_add_liquibase", author = "jandroav")
   def migration001(implicit db: MongoDatabase) = {
     Candidate(
       candidate = "liquibase",


### PR DESCRIPTION
Hello team, we have a question about https://github.com/sdkman/sdkman-cli/wiki/Well-formed-SDK-archives.

We are already generating a `zip` file for `liquibase`. It almost complies with the **Well-formed-SDK-archives** guide except for the bin folder. We are shipping the executable in the root folder:

![image](https://github.com/sdkman/sdkman-db-migrations/assets/67458478/57b169ba-bb73-4676-acb5-836b4fb1bf82)

We are ok if we need to generate a different `zip` file for `SDKMAM` like the following:

![image](https://github.com/sdkman/sdkman-db-migrations/assets/67458478/8a04f482-1318-4787-9a74-78aaf97c39d0)

But we would like to know if we could create a `bin` directory and symlink the required files into it (or move to `bin and symlink to root dir). This involves the creation of a `tar. which supports symbolic links instead of a `zip` file.
