### PR TITLE
Upgraded to Tomcat April '24 release

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
+++ b/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
@@ -117,4 +117,31 @@ class TomcatMigration {
     setCandidateDefault("tomcat", "10.1.14")
   }
 
+  @ChangeSet(
+    order = "016",
+    id = "016-update_tomcat_versions",
+    author = "stefanpenndorf"
+  )
+  def migration016(implicit db: MongoDatabase): Document = {
+    removeVersion("tomcat", "11.0.0-M12")
+
+    List(
+      "8"  -> "8.5.100",
+      "9"  -> "9.0.88",
+      "10" -> "10.1.20",
+      "11" -> "11.0.0-M19"
+    ).map {
+        case (series: String, version: String) =>
+          Version(
+            candidate = "tomcat",
+            version = version,
+            url =
+              s"https://archive.apache.org/dist/tomcat/tomcat-$series/v$version/bin/apache-tomcat-$version.zip"
+          )
+      }
+      .validate()
+      .insert()
+    setCandidateDefault("tomcat", "10.1.14")
+  }
+
 }


### PR DESCRIPTION
Upgrade includes
- Tomcat 8.5.100 from 8.5 line
- Tomcat 9.0.88 from 9.0 line
- Tomcat 10.1.20 from 10.1 line (will be new default version)
- Tomcat 11.0.0-M19 as latest from 11 line (this is the latest alpha release)

Tomcat 11.0.0-M12 dropped because it's only an alpha release and superseded by M19.