### PR TITLE
Add Spark 3.5.1 and older patches

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/SparkMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/SparkMigrations.scala
@@ -5,76 +5,72 @@ import com.mongodb.client.MongoDatabase
 
 @ChangeLog(order = "007")
 class SparkMigrations {
-  @ChangeSet(
-    order = "023",
-    id = "023-add_spark_3.2.3",
-    author = "sekikn"
-  )
-  def migration023(implicit db: MongoDatabase) = {
-    Version(
-      "spark",
-      "3.2.3",
-      "https://archive.apache.org/dist/spark/spark-3.2.3/spark-3.2.3-bin-hadoop3.2.tgz"
-    ).validate()
-      .insert()
-  }
 
   @ChangeSet(
-    order = "024",
-    id = "024-add_spark_3.3.2",
-    author = "sekikn"
-  )
-  def migration024(implicit db: MongoDatabase) = {
-    Version(
-      "spark",
-      "3.3.2",
-      "https://archive.apache.org/dist/spark/spark-3.3.2/spark-3.3.2-bin-hadoop3.tgz"
-    ).validate()
-      .insert()
-      .asCandidateDefault()
-  }
-
-  @ChangeSet(
-    order = "025",
-    id = "025-add_spark_3.4.0",
-    author = "chethanuk"
-  )
-  def migration025(implicit db: MongoDatabase) = {
-    Version(
-      "spark",
-      "3.4.0",
-      "https://archive.apache.org/dist/spark/spark-3.4.0/spark-3.4.0-bin-hadoop3.tgz"
-    ).validate()
-      .insert()
-      .asCandidateDefault()
-  }
-
-  @ChangeSet(
-    order = "026",
-    id = "026-add_spark_3.4.1",
+    order = "028",
+    id = "028-add_spark_3.5.1",
     author = "cphbrt"
   )
-  def migration026(implicit db: MongoDatabase) = {
+  def migration028(implicit db: MongoDatabase) = {
     Version(
       "spark",
-      "3.4.1",
-      "https://archive.apache.org/dist/spark/spark-3.4.1/spark-3.4.1-bin-hadoop3.tgz"
-    ).validate()
-      .insert()
-  }
-
-  @ChangeSet(
-    order = "027",
-    id = "027-add_spark_3.5.0",
-    author = "cphbrt"
-  )
-  def migration027(implicit db: MongoDatabase) = {
+      "2.2.2",
+      "https://archive.apache.org/dist/spark/spark-2.2.2/spark-2.2.2-bin-hadoop2.7.tgz"
+    ).validate().insert()
     Version(
       "spark",
-      "3.5.0",
-      "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz"
-    ).validate()
-      .insert()
-      .asCandidateDefault()
+      "2.2.3",
+      "https://archive.apache.org/dist/spark/spark-2.2.3/spark-2.2.3-bin-hadoop2.7.tgz"
+    ).validate().insert()
+    Version(
+      "spark",
+      "2.3.4",
+      "https://archive.apache.org/dist/spark/spark-2.3.4/spark-2.3.4-bin-hadoop2.7.tgz"
+    ).validate().insert()
+    Version(
+      "spark",
+      "2.4.8",
+      "https://archive.apache.org/dist/spark/spark-2.4.8/spark-2.4.8-bin-hadoop2.7.tgz"
+    ).validate().insert()
+    Version(
+      "spark",
+      "3.0.3",
+      "https://archive.apache.org/dist/spark/spark-3.0.3/spark-3.0.3-bin-hadoop3.2.tgz"
+    ).validate().insert()
+    Version(
+      "spark",
+      "3.1.3",
+      "https://archive.apache.org/dist/spark/spark-3.1.3/spark-3.1.3-bin-hadoop3.2.tgz"
+    ).validate().insert()
+    Version(
+      "spark",
+      "3.2.4",
+      "https://archive.apache.org/dist/spark/spark-3.2.4/spark-3.2.4-bin-hadoop3.2.tgz"
+    ).validate().insert()
+    Version(
+      "spark",
+      "3.3.3",
+      "https://archive.apache.org/dist/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz"
+    ).validate().insert()
+    Version(
+      "spark",
+      "3.3.4",
+      "https://archive.apache.org/dist/spark/spark-3.3.4/spark-3.3.4-bin-hadoop3.tgz"
+    ).validate().insert()
+    Version(
+      "spark",
+      "3.4.2",
+      "https://archive.apache.org/dist/spark/spark-3.4.2/spark-3.4.2-bin-hadoop3.tgz"
+    ).validate().insert()
+    Version(
+      "spark",
+      "3.4.3",
+      "https://archive.apache.org/dist/spark/spark-3.4.3/spark-3.4.3-bin-hadoop3.tgz"
+    ).validate().insert()
+    Version(
+      "spark",
+      "3.5.1",
+      "https://archive.apache.org/dist/spark/spark-3.5.1/spark-3.5.1-bin-hadoop3.tgz"
+    ).validate().insert().asCandidateDefault()
   }
 }


### PR DESCRIPTION
Hi! I've made similar contributions to this repo in https://github.com/sdkman/sdkman-db-migrations/pull/672 and https://github.com/sdkman/sdkman-db-migrations/pull/614.

The primary goal of this PR is to add Spark `3.5.1`. I added the other missing patch versions back to `2.0.2`, the oldest available in sdkman. Let me know if that was too ambitious, and I can remove those and leave `3.5.1`.

_Updates_:
- Force push https://github.com/sdkman/sdkman-db-migrations/commit/9dfa4a4882da48a63cf3810bcbd79eb10fcff75b fixed a missing author field in a `ChangeSet` annotation.