### PR TITLE
Upgraded to Tomcat September '24 release

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
+++ b/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
@@ -144,4 +144,31 @@ class TomcatMigration {
     setCandidateDefault("tomcat", "10.1.14")
   }
 
+  @ChangeSet(
+    order = "017",
+    id = "017-update_tomcat_versions",
+    author = "stefanpenndorf"
+  )
+  def migration017(implicit db: MongoDatabase): Document = {
+    removeVersion("tomcat", "11.0.0-M19")
+    removeVersion("tomcat", "8.5.100") // Tomcat 8.5 EOL on March, 31st 2024
+
+    List(
+      "9"  -> "9.0.95",
+      "10" -> "10.1.30",
+      "11" -> "11.0.0-M26"
+    ).map {
+        case (series: String, version: String) =>
+          Version(
+            candidate = "tomcat",
+            version = version,
+            url =
+              s"https://archive.apache.org/dist/tomcat/tomcat-$series/v$version/bin/apache-tomcat-$version.zip"
+          )
+      }
+      .validate()
+      .insert()
+    setCandidateDefault("tomcat", "10.1.30")
+  }
+
 }


### PR DESCRIPTION
Upgrade includes
- Tomcat 9.0.95 from 9.0 line
- Tomcat 10.1.30 from 10.1 line (will be new default version)
- Tomcat 11.0.0-M26 as latest from 11 line (this is the latest beta release)

Tomcat 11.0.0-M19 dropped because it's only an alpha release and superseded by M26.