### PR TITLE
Tomcat February update

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
+++ b/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
@@ -197,4 +197,28 @@ class TomcatMigration {
     setCandidateDefault("tomcat", "11.0.0")
   }
 
+  @ChangeSet(
+    order = "019",
+    id = "019-update_tomcat_versions",
+    author = "stefanpenndorf"
+  )
+  def migration019(implicit db: MongoDatabase): Document = {
+    List(
+      "9"  -> "9.0.100",
+      "10" -> "10.1.36",
+      "11" -> "11.0.4"
+    ).map {
+        case (series: String, version: String) =>
+          Version(
+            candidate = "tomcat",
+            version = version,
+            url =
+              s"https://archive.apache.org/dist/tomcat/tomcat-$series/v$version/bin/apache-tomcat-$version.zip"
+          )
+      }
+      .validate()
+      .insert()
+    setCandidateDefault("tomcat", "11.0.4")
+  }
+
 }


### PR DESCRIPTION
### Upgraded to Tomcat February '25 release

Upgrade includes
- Tomcat 9.0.100 from 9.0 line
- Tomcat 10.1.36 from 10.1 line
- Tomcat 11.0.4 from 11.0 line (will be new default version)

### Remove obsolete Versions from Tomcat 7 and Tomcat 8

- Tomcat 7 is EOL 31 March 2021
- Tomcat 8 is EOL 31 March 2024