### PR TITLE
Add jQAssistant to SDKMAN (cf. jqassistant/jqassistant#745)

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/JqaMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JqaMigrations.scala
@@ -1,0 +1,18 @@
+package io.sdkman.changelogs
+
+import com.github.mongobee.changeset.{ChangeLog, ChangeSet}
+import com.mongodb.client.MongoDatabase
+
+@ChangeLog(order = "089")
+class JqaMigrations {
+  @ChangeSet(order = "001", id = "001_add_jqa_2_6_0", author = "ascheman")
+  def migration001(implicit db: MongoDatabase): Candidate = {
+    Candidate(
+      candidate = "jqassistant",
+      name = "jQAssistant",
+      description =
+        "jQAssistant is an open-source tool for software analytics, enabling you to gain insights into your systems, verify design implementation, and create living documentation. By scanning code and configurations into a Neo4j graph database, it helps maintain software quality and bridge the gap between documentation and implementation.",
+      websiteUrl = "https://jqassistant.org"
+    ).insert()
+  }
+}


### PR DESCRIPTION
I am raising this on behalf of the jQA project (where I am only a contributor, not a committer).
@DirkMahler has already requested API credentials, so he will be in charge to create new versions beyond the current release (2.6.0).

This contributes to jqassistant/jqassistant#745.