### PR TITLE
Upgraded to Tomcat March '25 release

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
+++ b/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
@@ -221,4 +221,28 @@ class TomcatMigration {
     setCandidateDefault("tomcat", "11.0.4")
   }
 
+  @ChangeSet(
+    order = "020",
+    id = "020-update_tomcat_versions",
+    author = "stefanpenndorf"
+  )
+  def migration020(implicit db: MongoDatabase): Document = {
+    List(
+      "9"  -> "9.0.102",
+      "10" -> "10.1.39",
+      "11" -> "11.0.5"
+    ).map {
+        case (series: String, version: String) =>
+          Version(
+            candidate = "tomcat",
+            version = version,
+            url =
+              s"https://archive.apache.org/dist/tomcat/tomcat-$series/v$version/bin/apache-tomcat-$version.zip"
+          )
+      }
+      .validate()
+      .insert()
+    setCandidateDefault("tomcat", "11.0.5")
+  }
+
 }


### PR DESCRIPTION
Upgrade includes
- Tomcat 9.0.102 from 9.0 line
- Tomcat 10.1.39 from 10.1 line
- Tomcat 11.0.5 from 11.0 line (will be new default version)

The Tomcat releases 9.0.101, 10.1.37 and 10.1.38 have been skipped by Tomcat team.