### PR TITLE
Upgraded to Tomcat April '25 release

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
+++ b/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
@@ -245,4 +245,28 @@ class TomcatMigration {
     setCandidateDefault("tomcat", "11.0.5")
   }
 
+  @ChangeSet(
+    order = "021",
+    id = "021-update_tomcat_versions",
+    author = "stefanpenndorf"
+  )
+  def migration021(implicit db: MongoDatabase): Document = {
+    List(
+      "9"  -> "9.0.104",
+      "10" -> "10.1.40",
+      "11" -> "11.0.6"
+    ).map {
+        case (series: String, version: String) =>
+          Version(
+            candidate = "tomcat",
+            version = version,
+            url =
+              s"https://archive.apache.org/dist/tomcat/tomcat-$series/v$version/bin/apache-tomcat-$version.zip"
+          )
+      }
+      .validate()
+      .insert()
+    setCandidateDefault("tomcat", "11.0.6")
+  }
+
 }


### PR DESCRIPTION
This release fixes CVE-2025-31650 and CVE-2025-31651.

Upgrade includes
- Tomcat 9.0.104 from 9.0 line
- Tomcat 10.1.40 from 10.1 line
- Tomcat 11.0.6 from 11.0 line (will be the new default version)

Tomcat team has skipped the Tomcat release 9.0.103.