### PR TITLE
Adding BoxLang vendor

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/BoxLang.scala
+++ b/src/main/scala/io/sdkman/changelogs/BoxLang.scala
@@ -1,0 +1,18 @@
+package io.sdkman.changelogs
+
+import com.github.mongobee.changeset.{ChangeLog, ChangeSet}
+import com.mongodb.client.MongoDatabase
+
+@ChangeLog(order = "090")
+class BogusMigrations {
+    @ChangeSet(order = "001", id = "001_add_boxlang", author = "lmajano")
+    def migration001(implicit db: MongoDatabase) = {
+        Candidate(
+          candidate = "boxlang",
+          name = "BoxLang",
+          description = "A modern, dynamically and loosely typed scripting language for multiple runtimes.",
+          websiteUrl = "https://www.boxlang.io/",
+          distribution = "UNIVERSAL"
+        ).insert()
+    }
+}


### PR DESCRIPTION
Adding BoxLang as a vendor so we can publish our BoxLang targets to sdkman.

BoxLang is a modern dynamic JVM language that can be deployed on multiple runtimes: operating system (Windows/Mac/*nix/Embedded), web server, lambda, iOS, android, web assembly, and more. 

More information at www.boxlang.io