### PR TITLE
Upgraded to Tomcat August '25 release

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
+++ b/src/main/scala/io/sdkman/changelogs/TomcatMigration.scala
@@ -293,4 +293,28 @@ class TomcatMigration {
     setCandidateDefault("tomcat", "11.0.7")
   }
 
+  @ChangeSet(
+    order = "023",
+    id = "023-update_tomcat_versions",
+    author = "stefanpenndorf"
+  )
+  def migration023(implicit db: MongoDatabase): Document = {
+    List(
+      "9"  -> "9.0.108",
+      "10" -> "10.1.44",
+      "11" -> "11.0.10"
+    ).map {
+        case (series: String, version: String) =>
+          Version(
+            candidate = "tomcat",
+            version = version,
+            url =
+              s"https://archive.apache.org/dist/tomcat/tomcat-$series/v$version/bin/apache-tomcat-$version.zip"
+          )
+      }
+      .validate()
+      .insert()
+    setCandidateDefault("tomcat", "11.0.10")
+  }
+
 }


### PR DESCRIPTION
Upgrade includes
- Tomcat 9.0.108 from 9.0 line
- Tomcat 10.1.44 from 10.1 line
- Tomcat 11.0.10 from 11.0 line (will be the new default version)