### PR TITLE
Add ksrc candidate

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/KsrcMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/KsrcMigrations.scala
@@ -3,7 +3,7 @@ package io.sdkman.changelogs
 import com.github.mongobee.changeset.{ChangeLog, ChangeSet}
 import com.mongodb.client.MongoDatabase
 
-@ChangeLog(order = "090")
+@ChangeLog(order = "092")
 class KsrcMigrations {
   @ChangeSet(
     order = "001",

--- a/src/main/scala/io/sdkman/changelogs/KsrcMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/KsrcMigrations.scala
@@ -1,0 +1,21 @@
+package io.sdkman.changelogs
+
+import com.github.mongobee.changeset.{ChangeLog, ChangeSet}
+import com.mongodb.client.MongoDatabase
+
+@ChangeLog(order = "090")
+class KsrcMigrations {
+  @ChangeSet(
+    order = "001",
+    id = "001_add_ksrc_candidate",
+    author = "respawn-app"
+  )
+  def migration001(implicit db: MongoDatabase) =
+    Candidate(
+      candidate = "ksrc",
+      name = "ksrc",
+      description = "Let your AI agents search and read 3rd-party Kotlin dependency sources",
+      websiteUrl = "https://github.com/respawn-app/ksrc",
+      distribution = "PLATFORM_SPECIFIC"
+    ).insert()
+}


### PR DESCRIPTION
Adds the ksrc candidate (platform-specific) with description and GitHub URL as part of vendor onboarding

See https://github.com/respawn-app/ksrc/issues/12