### PR TITLE
Add Atmosphere CLI candidate

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/AtmosphereMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/AtmosphereMigrations.scala
@@ -3,7 +3,7 @@ package io.sdkman.changelogs
 import com.github.mongobee.changeset.{ChangeLog, ChangeSet}
 import com.mongodb.client.MongoDatabase
 
-@ChangeLog(order = "075")
+@ChangeLog(order = "090")
 class AtmosphereMigrations {
 
   @ChangeSet(

--- a/src/main/scala/io/sdkman/changelogs/AtmosphereMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/AtmosphereMigrations.scala
@@ -1,0 +1,24 @@
+package io.sdkman.changelogs
+
+import com.github.mongobee.changeset.{ChangeLog, ChangeSet}
+import com.mongodb.client.MongoDatabase
+
+@ChangeLog(order = "075")
+class AtmosphereMigrations {
+
+  @ChangeSet(
+    order = "001",
+    id = "001_add_atmosphere_candidate",
+    author = "jfarcand"
+  )
+  def migration001(implicit db: MongoDatabase) = {
+    Candidate(
+      candidate = "atmosphere",
+      name = "Atmosphere",
+      description =
+        "Real-time transport layer for Java AI agents. Build once with @Agent — deliver over WebTransport/HTTP3, WebSocket, SSE, gRPC, MCP, A2A, AG-UI, or any transport.",
+      websiteUrl = "https://github.com/Atmosphere/atmosphere",
+      distribution = "UNIVERSAL"
+    ).insert()
+  }
+}


### PR DESCRIPTION
## New Candidate: Atmosphere

**Atmosphere** is a real-time transport layer for Java AI agents. Build once with `@Agent` — deliver over WebTransport/HTTP3, WebSocket, SSE, gRPC, MCP, A2A, AG-UI, or any transport.

- **Website:** https://github.com/Atmosphere/atmosphere
- **Documentation:** https://atmosphere.github.io/docs/
- **Distribution type:** `UNIVERSAL` (self-contained shell script, runs on any platform with a JDK)
- **Author:** Jean-François Arcand (@jfarcand)
- **License:** Apache 2.0
- **Since:** 2008 (17 years of production use)

### CLI Overview

The `atmosphere` CLI lets developers:
- `atmosphere install` — interactive sample picker (20+ samples)
- `atmosphere compose` — scaffold multi-agent projects
- `atmosphere checkpoint` — inspect durable workflow checkpoints

The CLI is a self-contained POSIX shell script (~72KB) with no external dependencies beyond a JDK.

### SDK Archive Format

We will publish releases as ZIP archives containing `bin/atmosphere` (the shell script) to the GitHub Releases page, compatible with SDKMAN's expected archive structure.