### PR TITLE
Update Jetty to 10.0.26, 11.0.26, 12.0.34 and 12.1.8

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/JettyMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JettyMigrations.scala
@@ -28,6 +28,30 @@ class JettyMigrations {
       .validate()
       .insert()
     setCandidateDefault("jetty", "12.0.14")
+  }
 
+  @ChangeSet(
+    order = "006",
+    id = "006-update_jetty_versions",
+    author = "lachlan-roberts"
+  )
+  def migration006(implicit db: MongoDatabase) = {
+    List(
+      "10"   -> "10.0.26",
+      "11"   -> "11.0.26",
+      "12.0" -> "12.0.34",
+      "12.1" -> "12.1.8"
+    ).map {
+        case (series: String, version: String) =>
+          Version(
+            candidate = "jetty",
+            version = version,
+            url =
+              s"https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$version/jetty-home-$version.zip"
+          )
+      }
+      .validate()
+      .insert()
+    setCandidateDefault("jetty", "12.1.8")
   }
 }


### PR DESCRIPTION
It has been a while since the Jetty version has been updated here.

- Jetty 10 and 11 are now EOL so I have updated them to `10.0.26` and `11.0.26` which will be the last public releases of these lines. 
- Update from `12.0.14` to `12.0.34`.
- Introduce Jetty `12.1.x` versions, starting from `12.1.8` and setting this as the default.
