### PR TITLE
Add Jenesis candidate

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/JenesisMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JenesisMigrations.scala
@@ -1,0 +1,23 @@
+package io.sdkman.changelogs
+
+import com.github.mongobee.changeset.{ChangeLog, ChangeSet}
+import com.mongodb.client.MongoDatabase
+
+@ChangeLog(order = "094")
+class JenesisMigrations {
+  @ChangeSet(
+    order = "001",
+    id = "001_add_jenesis_candidate",
+    author = "raphw"
+  )
+  def migration001(implicit db: MongoDatabase) =
+    Candidate(
+      candidate = "jenesis",
+      name = "Jenesis",
+      description = """A Java-native, Java-module-focused build tool.
+          |Builds are incremental and cache-friendly,
+          |configured in plain Java.""".stripMargin,
+      websiteUrl = "https://jenesis.build",
+      distribution = "UNIVERSAL"
+    ).insert()
+}


### PR DESCRIPTION
## Onboards `jenesis` candidate

Adds the `jenesis` candidate per the [vendor onboarding process](https://github.com/sdkman/sdkman-cli/wiki/Vendor-onboarding-process). No versions are inserted in this migration; releases will follow via the vendor API once credentials are provisioned.

- Repository: https://github.com/raphw/jenesis
- Homepage: https://jenesis.build
- License: Apache-2.0
- Distribution: `UNIVERSAL`

## What Jenesis is

Jenesis is a Java-native build tool focused on the Java module system. Three properties define it:

1. **Configured in plain Java.** There is no external DSL: no XML, Groovy, or Kotlin script. Build descriptors are regular Java code that compiles against the public `build.jenesis` API.
2. **Zero installation.** The launcher is itself a `.java` source file executed via the JVM's single-file launcher. A clone of the project plus a JDK is the entire setup: no wrapper script, lockfile, or pre-built binary required.
3. **Incremental and cache-friendly.** Builds are expressed as a step DAG with content-addressed inputs. Each step reruns only when its inputs change; unchanged steps are served from cache. Builds are reproducible from a clean clone.

The default `Layout.AUTO` inspects the project root: a `module-info.java` selects the modular pipeline, a `pom.xml` selects the Maven-compatible one. The same `java build/jenesis/Project.java` invocation works for both.

## Archive shape

The SDKMAN distribution is a well-formed `UNIVERSAL` zip:

    jenesis-<version>/
    ├── bin/
    │   ├── jenesis      (Unix launcher, exec bit set)
    │   └── jenesis.bat  (Windows launcher)
    ├── lib/
    │   └── build.jenesis-<version>.jar
    └── LICENSE

Both launchers prefer `JAVA_HOME/bin/java`, fall back to `java` on `PATH`, and require Java 25 or newer (printing a readable error otherwise). The bundled jar's module descriptor carries a `main-class` attribute, so launch is `java -p lib -m build.jenesis "\$@"`.