### PR TITLE
Add regulus-cli candidate

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/RegulusMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/RegulusMigrations.scala
@@ -1,0 +1,27 @@
+package io.sdkman.changelogs
+
+import com.github.mongobee.changeset.{ChangeLog, ChangeSet}
+import com.mongodb.client.MongoDatabase
+
+@ChangeLog(order = "095")
+class RegulusMigrations {
+  @ChangeSet(
+    order = "001",
+    id = "001_add_regulus_candidate",
+    author = "dipankar"
+  )
+  def migration001(implicit db: MongoDatabase) =
+    Candidate(
+      candidate = "regulus-cli",
+      name = "Regulus CLI",
+      description = """The Regulus compliance plane — scaffold a regulated
+          |Google ADK agent in 60 seconds. Encodes 10 EU + UK regulations
+          |(EU AI Act, GDPR, DORA, NIS2, EHDS, UK GDPR, FCA SYSC, PRA SS1/23,
+          |PRA SS2/21, NHS DSPT) and 6 governance frameworks as runtime
+          |ADK plugin profiles. Ships a CLI for generating compliant
+          |projects and a Spring Boot starter that auto-wires every
+          |plugin from `application.yaml`.""".stripMargin,
+      websiteUrl = "https://regulus.neullabs.com",
+      distribution = "UNIVERSAL"
+    ).insert()
+}


### PR DESCRIPTION
Adds the **regulus-cli** candidate to SDKMAN!.

[Regulus](https://regulus.neullabs.com) is the EU + UK compliance plane for Google ADK. It encodes 10 regulations (EU AI Act, GDPR, DORA, NIS2, EHDS, UK GDPR, FCA SYSC, PRA SS1/23, PRA SS2/21, NHS DSPT) and 6 governance frameworks as runtime ADK plugin profiles, with hash-chained audit envelopes and GRC evidence adapters. The CLI scaffolds a compliant ADK agent in 60 seconds:

```
regulus init my-agent --profiles=eu-ai-act,uk-gdpr,fca-sysc \
                     --frameworks=nist-ai-rmf,iso-42001
```

After this PR merges, the canonical install path becomes:

```
sdk install regulus-cli
```

This PR follows the [Vendor Onboarding Process](https://github.com/sdkman/sdkman-cli/wiki/Vendor-onboarding-process) — it inserts the `Candidate(...)` entry only; the v0.2.1 binary will be published separately via the Vendor API once API credentials are issued (a follow-up email to info@sdkman.io per the wiki).

Per the wiki: versions are *not* added in this PR. I am registering the candidate first.