### PR TITLE
Adds Eliya as a new vendor for the  candidate.

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/package.scala
+++ b/src/main/scala/io/sdkman/changelogs/package.scala
@@ -114,6 +114,10 @@ package object changelogs {
     override val id = "tem"
   }
 
+  case object Eliya extends Vendor {
+    override val id = "eliya"
+  }
+
   case object Graal extends Vendor {
     override val id = "grl"
   }


### PR DESCRIPTION
- Web: https://asymm.systems/product/eliya
- Distribution Project: https://asymm.systems/product/eliya
- Vendor: Asymm Systems (Pvt) Ltd
- Vendor ID:
- Distribution: OpenJDK 25 LTS-based
- License: GPL v2 with Classpath Exception (matches upstream OpenJDK)
- Initial release: https://github.com/asymmsystems/eliya-jdk/releases/tag/eliya-jdk-25.0.3
- Platforms (initial): Linux x86_64, Linux aarch64
- Future platforms: macOS aarch64 (Phase 2 demand-gated), Windows x64 (Phase 3 demand-gated)

This PR follows the precedent of #448 (Eclipse Temurin) — adds the vendor case object only. Version registrations will follow via the API after credentials are received.

Discord #vendors thread:~ https://discord.com/channels/1245471991117512754/1245486354498977862/1514128544136036424