### PR TITLE
Add kUML 0.20.5 initial release

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/KumlMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/KumlMigrations.scala
@@ -19,4 +19,41 @@ class KumlMigrations {
       websiteUrl = "https://kuml.dev",
       distribution = "PLATFORM_SPECIFIC"
     ).insert()
+
+  @ChangeSet(order = "002", id = "002_add_kuml_0_20_5", author = "betschwa")
+  def migration002(implicit db: MongoDatabase) = {
+    List(
+      Version(
+        "kuml",
+        "0.20.5",
+        "https://github.com/kuml-dev/kUML/releases/download/v0.20.5/kuml-runtime-0.20.5-darwin-arm64.zip",
+        MacARM64
+      ),
+      Version(
+        "kuml",
+        "0.20.5",
+        "https://github.com/kuml-dev/kUML/releases/download/v0.20.5/kuml-runtime-0.20.5-darwin-x86_64.zip",
+        MacOSX
+      ),
+      Version(
+        "kuml",
+        "0.20.5",
+        "https://github.com/kuml-dev/kUML/releases/download/v0.20.5/kuml-runtime-0.20.5-linux-x86_64.zip",
+        Linux64
+      ),
+      Version(
+        "kuml",
+        "0.20.5",
+        "https://github.com/kuml-dev/kUML/releases/download/v0.20.5/kuml-runtime-0.20.5-linux-aarch64.zip",
+        LinuxARM64
+      ),
+      Version(
+        "kuml",
+        "0.20.5",
+        "https://github.com/kuml-dev/kUML/releases/download/v0.20.5/kuml-runtime-0.20.5-windows-x86_64.zip",
+        Windows
+      )
+    ).validate().insert()
+    setCandidateDefault("kuml", "0.20.5")
+  }
 }


### PR DESCRIPTION
Adds the initial version release for kUML 0.20.5 — a follow-up to PR #782 which registered the candidate.

**Platforms included:**
- `MAC_ARM64` — darwin-arm64
- `MAC_OSX` — darwin-x86_64
- `LINUX_64` — linux-x86_64
- `LINUX_ARM64` — linux-aarch64
- `Windows` — windows-x86_64

All archives are jlink-bundled self-contained runtimes (no JVM required on the user's machine), built via the `runtimeZip` Gradle task and published to GitHub Releases.

Version 0.20.5 is set as the candidate default.

/cc @marc0der — as discussed via email, this is the initial version release you asked for.