### PR TITLE
Add jpx candidate

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/JpxMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/JpxMigrations.scala
@@ -1,0 +1,23 @@
+package io.sdkman.changelogs
+
+import com.github.mongobee.changeset.{ChangeLog, ChangeSet}
+import com.mongodb.client.MongoDatabase
+
+@ChangeLog(order = "096")
+class JpxMigrations {
+  @ChangeSet(
+    order = "001",
+    id = "001_add_jpx_candidate",
+    author = "raphw"
+  )
+  def migration001(implicit db: MongoDatabase) =
+    Candidate(
+      candidate = "jpx",
+      name = "JPX",
+      description = """A Java-native, Java-module-focused application runner.
+          |Name a module (or Maven coordinate) and it fetches,
+          |caches and runs the implied application. """.stripMargin,
+      websiteUrl = "https://jenesis.build",
+      distribution = "UNIVERSAL"
+    ).insert()
+}


### PR DESCRIPTION
## New candidate: `jpx`

`jpx` is a Java-native application runner from the Jenesis project - the same project behind the existing **`jenesis`** candidate (changelog `094`).

> A Java-native, Java-module-focused application runner. Name a module (or Maven coordinate) and it fetches, caches and runs the implied application.

Where `jenesis` **builds** Java projects, `jpx` **runs** already-published ones: give it a module name or a Maven coordinate and it resolves the module and its dependencies onto the Java module path, caches them, and runs the application - no project checkout and no manual install.

    jpx some.module

The above shell command would resolve the above module from the module repository overlay of Maven Central, download the module and its dependencies, and execute it on the command line.

## Why a separate candidate, not part of `jenesis`

The two are distinct tools despite building on the same Java project. One is focused on users of Java applications, the other one is focused on builders of such application. JPX is built with component that Jenesis already delivers, and under normal circumstances the code bases would be two modules with JPX depending on Jenesis. This does however break the source code executability of Jenesis such that both projects share a Java code base. I did however find it non-intuitive if JPX would be installed alongside the Jenesis-family of commands.

## Migration

`JpxMigrations.scala` — `@ChangeLog(order = "096")`; candidate `jpx`, name `JPX`, distribution `UNIVERSAL`, website https://jenesis.build. Structurally identical to the accepted `jenesis` migration.

## Credentials

If possible, I would publish the project with the same credentials. As of now I have no plan to split the projects and they will be released simultaneously. 

Reference: https://jenesis.build/jpx/