### PR TITLE
Add tesseraql candidate

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/TesseraqlMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/TesseraqlMigrations.scala
@@ -1,0 +1,24 @@
+package io.sdkman.changelogs
+
+import com.github.mongobee.changeset.{ChangeLog, ChangeSet}
+import com.mongodb.client.MongoDatabase
+
+@ChangeLog(order = "096")
+class TesseraqlMigrations {
+
+  @ChangeSet(
+    order = "001",
+    id = "001_add_tesseraql_candidate",
+    author = "n-ichimura"
+  )
+  def migration001(implicit db: MongoDatabase) = {
+    Candidate(
+      candidate = "tesseraql",
+      name = "TesseraQL",
+      description =
+        "TesseraQL is a SQL-first framework for hypermedia business applications: YAML routes, 2-way SQL files, and server-rendered HTML on Apache Camel.",
+      websiteUrl = "https://ingcreators.com/tesseraql",
+      distribution = "UNIVERSAL"
+    ).insert()
+  }
+}


### PR DESCRIPTION
## New candidate: tesseraql

TesseraQL is a SQL-first framework for hypermedia business applications — applications are authored as YAML routes and 2-way SQL files, rendered as server-side HTML on Apache Camel.

- Website: https://ingcreators.com/tesseraql/
- Source: https://github.com/ingcreators/tesseraql (Apache-2.0)
- SDK archive: the GitHub releases ship a well-formed universal ZIP (`tesseraql-<version>/bin/tesseraql` launcher + `lib/` fat jar), e.g. https://github.com/ingcreators/tesseraql/releases/download/v0.6.0/tesseraql-cli-0.6.0-dist.zip

Following the vendor onboarding process: this changeset declares the candidate only (no versions); the armoured GPG public key goes to info@sdkman.io separately for the Vendor API credentials.

`@ChangeLog(order = "096")` — next free order after the current highest (095).