### PR TITLE
Switch kuml candidate to UNIVERSAL distribution

### DIFF
--- a/src/main/scala/io/sdkman/changelogs/KumlMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/KumlMigrations.scala
@@ -56,4 +56,23 @@ class KumlMigrations {
     ).validate().insert()
     setCandidateDefault("kuml", "0.20.5")
   }
+
+  // kUML's SDKMAN! release pipeline no longer bundles a per-platform jlink JRE
+  // (see kuml-dev/kUML's `:kuml-cli:universalDist` Gradle task): SDKMAN!'s
+  // whole purpose is JDK version management via `sdk use java`, so shipping
+  // our own runtime five times over duplicated something the channel already
+  // manages. Switches the existing candidate from PLATFORM_SPECIFIC to
+  // UNIVERSAL and drops the now-inconsistent platform-specific 0.20.5
+  // entries (mixing distribution schemes for one candidate isn't supported).
+  // Future versions are UNIVERSAL archives published by the release
+  // pipeline's `sdkman-release` job once vendor onboarding completes.
+  @ChangeSet(
+    order = "003",
+    id = "003_switch_kuml_to_universal",
+    author = "betschwa"
+  )
+  def migration003(implicit db: MongoDatabase) = {
+    setCandidateDistribution("kuml", "UNIVERSAL")
+    removeAllVersions("kuml")
+  }
 }

--- a/src/main/scala/io/sdkman/changelogs/KumlMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/KumlMigrations.scala
@@ -61,18 +61,31 @@ class KumlMigrations {
   // (see kuml-dev/kUML's `:kuml-cli:universalDist` Gradle task): SDKMAN!'s
   // whole purpose is JDK version management via `sdk use java`, so shipping
   // our own runtime five times over duplicated something the channel already
-  // manages. Switches the existing candidate from PLATFORM_SPECIFIC to
-  // UNIVERSAL and drops the now-inconsistent platform-specific 0.20.5
-  // entries (mixing distribution schemes for one candidate isn't supported).
-  // Future versions are UNIVERSAL archives published by the release
-  // pipeline's `sdkman-release` job once vendor onboarding completes.
+  // manages. Per maintainer guidance on #790, a candidate hopping
+  // distribution schemes is removed and recreated fresh rather than
+  // mutating the `distribution` field in place; the now-inconsistent
+  // platform-specific 0.20.5 entries go with it (mixing distribution
+  // schemes for one candidate isn't supported). Anyone with 0.20.5 already
+  // installed locally keeps that install untouched — this only changes
+  // what the API serves going forward. Future versions are UNIVERSAL
+  // archives published by the release pipeline's `sdkman-release` job once
+  // vendor onboarding completes.
   @ChangeSet(
     order = "003",
-    id = "003_switch_kuml_to_universal",
+    id = "003_kuml_switch_to_universal",
     author = "betschwa"
   )
   def migration003(implicit db: MongoDatabase) = {
-    setCandidateDistribution("kuml", "UNIVERSAL")
     removeAllVersions("kuml")
+    removeCandidate("kuml")
+
+    Candidate(
+      candidate = "kuml",
+      name = "kUML",
+      description =
+        "kUML is a Kotlin-native DSL for UML 2, SysML 2, and C4 architecture modelling that compiles type-safe Kotlin sources to SVG diagrams through a configurable renderer pipeline.",
+      websiteUrl = "https://kuml.dev",
+      distribution = "UNIVERSAL"
+    ).insert()
   }
 }

--- a/src/main/scala/io/sdkman/changelogs/KumlMigrations.scala
+++ b/src/main/scala/io/sdkman/changelogs/KumlMigrations.scala
@@ -57,19 +57,6 @@ class KumlMigrations {
     setCandidateDefault("kuml", "0.20.5")
   }
 
-  // kUML's SDKMAN! release pipeline no longer bundles a per-platform jlink JRE
-  // (see kuml-dev/kUML's `:kuml-cli:universalDist` Gradle task): SDKMAN!'s
-  // whole purpose is JDK version management via `sdk use java`, so shipping
-  // our own runtime five times over duplicated something the channel already
-  // manages. Per maintainer guidance on #790, a candidate hopping
-  // distribution schemes is removed and recreated fresh rather than
-  // mutating the `distribution` field in place; the now-inconsistent
-  // platform-specific 0.20.5 entries go with it (mixing distribution
-  // schemes for one candidate isn't supported). Anyone with 0.20.5 already
-  // installed locally keeps that install untouched — this only changes
-  // what the API serves going forward. Future versions are UNIVERSAL
-  // archives published by the release pipeline's `sdkman-release` job once
-  // vendor onboarding completes.
   @ChangeSet(
     order = "003",
     id = "003_kuml_switch_to_universal",

--- a/src/main/scala/io/sdkman/changelogs/package.scala
+++ b/src/main/scala/io/sdkman/changelogs/package.scala
@@ -302,4 +302,13 @@ package object changelogs {
         Filters.eq("candidate", candidate),
         Updates.set("default", version)
       )
+
+  def setCandidateDistribution(candidate: String, distribution: String)(
+      implicit db: MongoDatabase
+  ): Document =
+    db.getCollection(CandidatesCollection)
+      .findOneAndUpdate(
+        Filters.eq("candidate", candidate),
+        Updates.set("distribution", distribution)
+      )
 }

--- a/src/main/scala/io/sdkman/changelogs/package.scala
+++ b/src/main/scala/io/sdkman/changelogs/package.scala
@@ -302,13 +302,4 @@ package object changelogs {
         Filters.eq("candidate", candidate),
         Updates.set("default", version)
       )
-
-  def setCandidateDistribution(candidate: String, distribution: String)(
-      implicit db: MongoDatabase
-  ): Document =
-    db.getCollection(CandidatesCollection)
-      .findOneAndUpdate(
-        Filters.eq("candidate", candidate),
-        Updates.set("distribution", distribution)
-      )
 }


### PR DESCRIPTION
kUML's SDKMAN! release no longer bundles a per-platform jlink JRE (see kuml-dev/kUML's new `:kuml-cli:universalDist` Gradle task): SDKMAN!'s whole purpose is JDK version management via `sdk use java`, so shipping a ~56 MB runtime five times over duplicated something the channel already manages — matching the shape every other JVM candidate here uses (`kotlin`, `gradle`, `scala`, `kotlin-toolchain`, …).

This adds changeset `003_kuml_switch_to_universal`, which removes the existing `kuml` candidate and its `0.20.5` platform-specific version entries, then recreates the candidate with `distribution = "UNIVERSAL"` — per @chloe41427's guidance in #790: delete + recreate rather than mutating the `distribution` field in place, since `removeCandidate`/`removeAllVersions` already exist and a one-off setter isn't needed.

Anyone with `0.20.5` already installed locally keeps that install untouched — this only changes what the API serves going forward. Future versions will be published as `UNIVERSAL` archives by kUML's release pipeline once vendor onboarding completes.

Closes the discussion in #790.